### PR TITLE
Cache StringNames

### DIFF
--- a/addons/terrabrush/Scripts/Clipmap.cs
+++ b/addons/terrabrush/Scripts/Clipmap.cs
@@ -92,10 +92,10 @@ public partial class Clipmap : Node3D {
         _clipmapMesh.Mesh = arrayMesh;
         UpdateAABB();
 
-        clipmapShader.SetShaderParameter("HeightmapTextures", TerrainZones.HeightmapTextures);
-        clipmapShader.SetShaderParameter("ZonesSize", (float) ZonesSize);
-        clipmapShader.SetShaderParameter("NumberOfZones", (float) TerrainZones.Zones.Count());
-		clipmapShader.SetShaderParameter("ZonesMap", TerrainZones.ZonesMap);
+        clipmapShader.SetShaderParameter(StringNames.HeightmapTextures, TerrainZones.HeightmapTextures);
+        clipmapShader.SetShaderParameter(StringNames.ZonesSize, (float) ZonesSize);
+        clipmapShader.SetShaderParameter(StringNames.NumberOfZones, (float) TerrainZones.Zones.Length);
+		clipmapShader.SetShaderParameter(StringNames.ZonesMap, TerrainZones.ZonesMap);
     }
 
     private void GenerateLevel(List<Vector3> vertices, List<Vector2> uvs, List<Color> colors, int level, int rowsPerLevel, float initialCellWidth) {

--- a/addons/terrabrush/Scripts/Foliage.cs
+++ b/addons/terrabrush/Scripts/Foliage.cs
@@ -32,7 +32,7 @@ public partial class Foliage : Node3D {
 
     public override void _Process(double delta) {
         if (!Engine.IsEditorHint()) {
-            this._foliageShader.SetShaderParameter("GlobalPosition", this.GetViewport()?.GetCamera3D()?.GlobalPosition ?? Vector3.Zero);
+            this._foliageShader.SetShaderParameter(StringNames.GlobalPosition, this.GetViewport()?.GetCamera3D()?.GlobalPosition ?? Vector3.Zero);
         }
     }
 
@@ -45,45 +45,45 @@ public partial class Foliage : Node3D {
         this._particles.DrawPass1 = this.Mesh;
         this._particles.MaterialOverride = this.MeshMaterial;
 
-        _foliageShader.SetShaderParameter("HeightmapTextures", TerrainZones.HeightmapTextures);
-        _foliageShader.SetShaderParameter("ZonesSize", (float) ZonesSize);
-        _foliageShader.SetShaderParameter("NumberOfZones", (float) TerrainZones.Zones.Count());
-		_foliageShader.SetShaderParameter("ZonesMap", TerrainZones.ZonesMap);
+        _foliageShader.SetShaderParameter(StringNames.HeightmapTextures, TerrainZones.HeightmapTextures);
+        _foliageShader.SetShaderParameter(StringNames.ZonesSize, (float) ZonesSize);
+        _foliageShader.SetShaderParameter(StringNames.NumberOfZones, (float) TerrainZones.Zones.Count());
+		_foliageShader.SetShaderParameter(StringNames.ZonesMap, TerrainZones.ZonesMap);
 
         if (TextureSets?.TextureSets != null) {
-            _foliageShader.SetShaderParameter("Splatmaps", TerrainZones.SplatmapsTextures);
-            _foliageShader.SetShaderParameter("Textures", Utils.TexturesToTextureArray(TextureSets.TextureSets.Select(x => x.AlbedoTexture)));
-            _foliageShader.SetShaderParameter("NumberOfTextures", TextureSets?.TextureSets?.Count() ?? 0);
-    		_foliageShader.SetShaderParameter("TextureDetail", this.TextureDetail);
+            _foliageShader.SetShaderParameter(StringNames.Splatmaps, TerrainZones.SplatmapsTextures);
+            _foliageShader.SetShaderParameter(StringNames.Textures, Utils.TexturesToTextureArray(TextureSets.TextureSets.Select(x => x.AlbedoTexture)));
+            _foliageShader.SetShaderParameter(StringNames.NumberOfTextures, TextureSets?.TextureSets?.Count() ?? 0);
+    		_foliageShader.SetShaderParameter(StringNames.TextureDetail, this.TextureDetail);
         }
 
-        _foliageShader.SetShaderParameter("FoliageTextures", TerrainZones.FoliagesTextures[foliageIndex]);
-        _foliageShader.SetShaderParameter("MeshScale", this.MeshScale);
-        _foliageShader.SetShaderParameter("WindStrength", this.WindStrength);
+        _foliageShader.SetShaderParameter(StringNames.FoliageTextures, TerrainZones.FoliagesTextures[foliageIndex]);
+        _foliageShader.SetShaderParameter(StringNames.MeshScale, this.MeshScale);
+        _foliageShader.SetShaderParameter(StringNames.WindStrength, this.WindStrength);
 
-        _foliageShader.SetShaderParameter("WaterTextures", TerrainZones.WaterTextures);
-        _foliageShader.SetShaderParameter("WaterFactor", this.WaterFactor);
+        _foliageShader.SetShaderParameter(StringNames.WaterTextures, TerrainZones.WaterTextures);
+        _foliageShader.SetShaderParameter(StringNames.WaterFactor, this.WaterFactor);
 
         if (NoiseTexture != null) {
             var noiseImage = new Image();
             noiseImage.CopyFrom(NoiseTexture.GetImage());
             noiseImage.Resize(this.ZonesSize, this.ZonesSize);
 
-            this._foliageShader.SetShaderParameter("NoiseTexture", ImageTexture.CreateFromImage(noiseImage));
+            this._foliageShader.SetShaderParameter(StringNames.NoiseTexture, ImageTexture.CreateFromImage(noiseImage));
         }
 
         if (Engine.IsEditorHint()) {
             this._particles.Amount = this.EditorMaximumRenderDistance * this.EditorMaximumRenderDistance;
 
-            this._foliageShader.SetShaderParameter("MaximumDistance", this.EditorMaximumRenderDistance);
+            this._foliageShader.SetShaderParameter(StringNames.MaximumDistance, this.EditorMaximumRenderDistance);
         } else {
             this._particles.Amount = this.MaximumRenderDistance * this.MaximumRenderDistance;
 
-            this._foliageShader.SetShaderParameter("MaximumDistance", this.MaximumRenderDistance);
+            this._foliageShader.SetShaderParameter(StringNames.MaximumDistance, this.MaximumRenderDistance);
         }
     }
 
     public void UpdateEditorCameraPosition(Camera3D viewportCamera) {
-        this._foliageShader?.SetShaderParameter("GlobalPosition", viewportCamera.GlobalPosition);
+        this._foliageShader?.SetShaderParameter(StringNames.GlobalPosition, viewportCamera.GlobalPosition);
     }
 }

--- a/addons/terrabrush/Scripts/Snow.cs
+++ b/addons/terrabrush/Scripts/Snow.cs
@@ -50,16 +50,16 @@ public partial class Snow : Node3D {
 
         _clipmap.CreateMesh();
 
-        _clipmap.Shader.SetShaderParameter("SnowTextures", TerrainZones.SnowTextures);
-        _clipmap.Shader.SetShaderParameter("SnowFactor", SnowDefinition.SnowFactor);
-        _clipmap.Shader.SetShaderParameter("SnowInnerOffset", SnowDefinition.SnowInnerOffset);
-        _clipmap.Shader.SetShaderParameter("SnowColorTexture", SnowDefinition.SnowColorTexture);
-        _clipmap.Shader.SetShaderParameter("SnowColorNormal", SnowDefinition.SnowColorNormal);
-        _clipmap.Shader.SetShaderParameter("SnowColorRoughness", SnowDefinition.SnowColorRoughness);
-        _clipmap.Shader.SetShaderParameter("SnowColorDetail", SnowDefinition.SnowColorDetail);
-        _clipmap.Shader.SetShaderParameter("Noise", SnowDefinition.Noise);
-        _clipmap.Shader.SetShaderParameter("NoiseFactor", SnowDefinition.NoiseFactor);
-        _clipmap.Shader.SetShaderParameter("Metallic", SnowDefinition.Metallic);
+        _clipmap.Shader.SetShaderParameter(StringNames.SnowTextures, TerrainZones.SnowTextures);
+        _clipmap.Shader.SetShaderParameter(StringNames.SnowFactor, SnowDefinition.SnowFactor);
+        _clipmap.Shader.SetShaderParameter(StringNames.SnowInnerOffset, SnowDefinition.SnowInnerOffset);
+        _clipmap.Shader.SetShaderParameter(StringNames.SnowColorTexture, SnowDefinition.SnowColorTexture);
+        _clipmap.Shader.SetShaderParameter(StringNames.SnowColorNormal, SnowDefinition.SnowColorNormal);
+        _clipmap.Shader.SetShaderParameter(StringNames.SnowColorRoughness, SnowDefinition.SnowColorRoughness);
+        _clipmap.Shader.SetShaderParameter(StringNames.SnowColorDetail, SnowDefinition.SnowColorDetail);
+        _clipmap.Shader.SetShaderParameter(StringNames.Noise, SnowDefinition.Noise);
+        _clipmap.Shader.SetShaderParameter(StringNames.NoiseFactor, SnowDefinition.NoiseFactor);
+        _clipmap.Shader.SetShaderParameter(StringNames.Metallic, SnowDefinition.Metallic);
     }
 
     public override void _PhysicsProcess(double delta) {

--- a/addons/terrabrush/Scripts/StringNames.cs
+++ b/addons/terrabrush/Scripts/StringNames.cs
@@ -1,0 +1,58 @@
+using Godot;
+
+namespace TerraBrush;
+
+internal static class StringNames {
+    public static readonly StringName HeightmapTextures = "HeightmapTextures";
+    public static readonly StringName ZonesSize = "ZonesSize";
+    public static readonly StringName NumberOfZones = "NumberOfZones";
+    public static readonly StringName ZonesMap = "ZonesMap";
+    public static readonly StringName GlobalPosition = "GlobalPosition";
+    public static readonly StringName Splatmaps = "Splatmaps";
+    public static readonly StringName Textures = "Textures";
+    public static readonly StringName NumberOfTextures = "NumberOfTextures";
+    public static readonly StringName TextureDetail = "TextureDetail";
+    public static readonly StringName FoliageTextures = "FoliageTextures";
+    public static readonly StringName MeshScale = "MeshScale";
+    public static readonly StringName WindStrength = "WindStrength";
+    public static readonly StringName WaterTextures = "WaterTextures";
+    public static readonly StringName WaterFactor = "WaterFactor";
+    public static readonly StringName NoiseTexture = "NoiseTexture";
+    public static readonly StringName MaximumDistance = "MaximumDistance";
+    public static readonly StringName SnowTextures = "SnowTextures";
+    public static readonly StringName SnowFactor = "SnowFactor";
+    public static readonly StringName SnowInnerOffset = "SnowInnerOffset";
+    public static readonly StringName SnowColorTexture = "SnowColorTexture";
+    public static readonly StringName SnowColorNormal = "SnowColorNormal";
+    public static readonly StringName SnowColorRoughness = "SnowColorRoughness";
+    public static readonly StringName SnowColorDetail = "SnowColorDetail";
+    public static readonly StringName Noise = "Noise";
+    public static readonly StringName NoiseFactor = "NoiseFactor";
+    public static readonly StringName Metallic = "Metallic";
+    public static readonly StringName NearestFilter = "NearestFilter";
+    public static readonly StringName TexturesDetail = "TexturesDetail";
+    public static readonly StringName HasNormalTextures = "HasNormalTextures";
+    public static readonly StringName HasRoughnessTextures = "HasRoughnessTextures";
+    public static readonly StringName HasHeightTextures = "HasHeightTextures";
+    public static readonly StringName UseAntitile = "UseAntitile";
+    public static readonly StringName BlendFactor = "BlendFactor";
+    public static readonly StringName WaterInnerOffset = "WaterInnerOffset";
+    public static readonly StringName WaterColor = "WaterColor";
+    public static readonly StringName FresnelColor = "FresnelColor";
+    public static readonly StringName Roughness = "Roughness";
+    public static readonly StringName NormalMap = "NormalMap";
+    public static readonly StringName NormalMap2 = "NormalMap2";
+    public static readonly StringName TimeScale = "TimeScale";
+    public static readonly StringName Strength = "Strength";
+    public static readonly StringName Wave = "Wave";
+    public static readonly StringName NoiseScale = "NoiseScale";
+    public static readonly StringName HeightScale = "HeightScale";
+    public static readonly StringName ColorDeep = "ColorDeep";
+    public static readonly StringName ColorShallow = "ColorShallow";
+    public static readonly StringName BeersLaw = "BeersLaw";
+    public static readonly StringName DepthOffset = "DepthOffset";
+    public static readonly StringName EdgeScale = "EdgeScale";
+    public static readonly StringName Near = "Near";
+    public static readonly StringName Far = "Far";
+    public static readonly StringName EdgeColor = "EdgeColor";
+}

--- a/addons/terrabrush/Scripts/Terrain.cs
+++ b/addons/terrabrush/Scripts/Terrain.cs
@@ -81,12 +81,12 @@ public partial class Terrain : Node3D {
     }
 
     private void TerrainSplatmapsUpdated() {
-        Clipmap.Shader.SetShaderParameter("Splatmaps", TerrainZones.SplatmapsTextures);
+        Clipmap.Shader.SetShaderParameter(StringNames.Splatmaps, TerrainZones.SplatmapsTextures);
     }
 
     public void TerrainWaterUpdated() {
-    	Clipmap.Shader.SetShaderParameter("WaterTextures", TerrainZones.WaterTextures);
-    	Clipmap.Shader.SetShaderParameter("WaterFactor", WaterFactor);
+    	Clipmap.Shader.SetShaderParameter(StringNames.WaterTextures, TerrainZones.WaterTextures);
+    	Clipmap.Shader.SetShaderParameter(StringNames.WaterFactor, WaterFactor);
     }
 
 	private void UpdateCollisionShape() {
@@ -182,7 +182,7 @@ public partial class Terrain : Node3D {
     }
 
 	private void UpdateTextures() {
-		Clipmap.Shader.SetShaderParameter("NearestFilter", NearestTextureFilter);
+		Clipmap.Shader.SetShaderParameter(StringNames.NearestFilter, NearestTextureFilter);
 
         var filterParamName = string.Empty;
         if (NearestTextureFilter) {
@@ -191,36 +191,36 @@ public partial class Terrain : Node3D {
 
         if (this.TextureSets?.TextureSets?.Length > 0) {
             var textureArray = Utils.TexturesToTextureArray(this.TextureSets.TextureSets.Select(x => x.AlbedoTexture));
-            Clipmap.Shader.SetShaderParameter("TexturesDetail", TextureSets.TextureSets.Select(x => x.TextureDetail <= 0 ? TextureDetail : x.TextureDetail).ToArray());
+            Clipmap.Shader.SetShaderParameter(StringNames.TexturesDetail, TextureSets.TextureSets.Select(x => x.TextureDetail <= 0 ? TextureDetail : x.TextureDetail).ToArray());
             Clipmap.Shader.SetShaderParameter($"Textures{filterParamName}", textureArray);
-            Clipmap.Shader.SetShaderParameter("NumberOfTextures", textureArray.GetLayers());
+            Clipmap.Shader.SetShaderParameter(StringNames.NumberOfTextures, textureArray.GetLayers());
 
             if (this.TextureSets.TextureSets.Any(x => x.NormalTexture != null)) {
                 var normalArray = Utils.TexturesToTextureArray(this.TextureSets.TextureSets.Select(x => x.NormalTexture));
                 Clipmap.Shader.SetShaderParameter($"Normals{filterParamName}", normalArray);
-                Clipmap.Shader.SetShaderParameter("HasNormalTextures", true);
+                Clipmap.Shader.SetShaderParameter(StringNames.HasNormalTextures, true);
             }
 
             if (this.TextureSets.TextureSets.Any(x => x.RoughnessTexture != null)) {
                 var roughnessArray = Utils.TexturesToTextureArray(this.TextureSets.TextureSets.Select(x => x.RoughnessTexture));
                 Clipmap.Shader.SetShaderParameter($"RoughnessTextures{filterParamName}", roughnessArray);
-                Clipmap.Shader.SetShaderParameter("HasRoughnessTextures", true);
+                Clipmap.Shader.SetShaderParameter(StringNames.HasRoughnessTextures, true);
             }
 
             if (this.TextureSets.TextureSets.Any(x => x.HeightTexture != null)) {
                 var heightArray = Utils.TexturesToTextureArray(this.TextureSets.TextureSets.Select(x => x.HeightTexture));
                 Clipmap.Shader.SetShaderParameter($"HeightTextures{filterParamName}", heightArray);
-                Clipmap.Shader.SetShaderParameter("HasHeightTextures", true);
+                Clipmap.Shader.SetShaderParameter(StringNames.HasHeightTextures, true);
             }
 
-            Clipmap.Shader.SetShaderParameter("UseAntitile", UseAntiTile);
-            Clipmap.Shader.SetShaderParameter("BlendFactor", HeightBlendFactor);
+            Clipmap.Shader.SetShaderParameter(StringNames.UseAntitile, UseAntiTile);
+            Clipmap.Shader.SetShaderParameter(StringNames.BlendFactor, HeightBlendFactor);
         } else if (DefaultTexture != null) {
             var textureArray = Utils.TexturesToTextureArray(new Texture2D[] {DefaultTexture});
-            Clipmap.Shader.SetShaderParameter("TexturesDetail", new int[] {TextureDetail});
+            Clipmap.Shader.SetShaderParameter(StringNames.TexturesDetail, new int[] {TextureDetail});
             Clipmap.Shader.SetShaderParameter($"Textures{filterParamName}", textureArray);
-            Clipmap.Shader.SetShaderParameter("NumberOfTextures", textureArray.GetLayers());
-            Clipmap.Shader.SetShaderParameter("UseAntitile", false);
+            Clipmap.Shader.SetShaderParameter(StringNames.NumberOfTextures, textureArray.GetLayers());
+            Clipmap.Shader.SetShaderParameter(StringNames.UseAntitile, false);
         }
 	}
 

--- a/addons/terrabrush/Scripts/Water.cs
+++ b/addons/terrabrush/Scripts/Water.cs
@@ -111,28 +111,28 @@ public partial class Water : Node3D {
 
         _clipmap.CreateMesh();
 
-        _clipmap.Shader.SetShaderParameter("WaterInnerOffset", WaterInnerOffset);
-        _clipmap.Shader.SetShaderParameter("WaterTextures", TerrainZones.WaterTextures);
-        _clipmap.Shader.SetShaderParameter("WaterFactor", WaterFactor);
-        _clipmap.Shader.SetShaderParameter("WaterColor", WaterColor);
-        _clipmap.Shader.SetShaderParameter("FresnelColor", FresnelColor);
-        _clipmap.Shader.SetShaderParameter("Metallic", Metallic);
-        _clipmap.Shader.SetShaderParameter("Roughness", Roughness);
-        _clipmap.Shader.SetShaderParameter("NormalMap", NormalMap);
-        _clipmap.Shader.SetShaderParameter("NormalMap2", NormalMap2);
-        _clipmap.Shader.SetShaderParameter("TimeScale", TimeScale);
-        _clipmap.Shader.SetShaderParameter("Strength", Strength);
-        _clipmap.Shader.SetShaderParameter("Wave", Wave);
-        _clipmap.Shader.SetShaderParameter("NoiseScale", NoiseScale);
-        _clipmap.Shader.SetShaderParameter("HeightScale", HeightScale);
-        _clipmap.Shader.SetShaderParameter("ColorDeep", ColorDeep);
-        _clipmap.Shader.SetShaderParameter("ColorShallow", ColorShallow);
-        _clipmap.Shader.SetShaderParameter("BeersLaw", BeersLaw);
-        _clipmap.Shader.SetShaderParameter("DepthOffset", DepthOffset);
-        _clipmap.Shader.SetShaderParameter("EdgeScale", EdgeScale);
-        _clipmap.Shader.SetShaderParameter("Near", Near);
-        _clipmap.Shader.SetShaderParameter("Far", Far);
-        _clipmap.Shader.SetShaderParameter("EdgeColor", EdgeColor);
+        _clipmap.Shader.SetShaderParameter(StringNames.WaterInnerOffset, WaterInnerOffset);
+        _clipmap.Shader.SetShaderParameter(StringNames.WaterTextures, TerrainZones.WaterTextures);
+        _clipmap.Shader.SetShaderParameter(StringNames.WaterFactor, WaterFactor);
+        _clipmap.Shader.SetShaderParameter(StringNames.WaterColor, WaterColor);
+        _clipmap.Shader.SetShaderParameter(StringNames.FresnelColor, FresnelColor);
+        _clipmap.Shader.SetShaderParameter(StringNames.Metallic, Metallic);
+        _clipmap.Shader.SetShaderParameter(StringNames.Roughness, Roughness);
+        _clipmap.Shader.SetShaderParameter(StringNames.NormalMap, NormalMap);
+        _clipmap.Shader.SetShaderParameter(StringNames.NormalMap2, NormalMap2);
+        _clipmap.Shader.SetShaderParameter(StringNames.TimeScale, TimeScale);
+        _clipmap.Shader.SetShaderParameter(StringNames.Strength, Strength);
+        _clipmap.Shader.SetShaderParameter(StringNames.Wave, Wave);
+        _clipmap.Shader.SetShaderParameter(StringNames.NoiseScale, NoiseScale);
+        _clipmap.Shader.SetShaderParameter(StringNames.HeightScale, HeightScale);
+        _clipmap.Shader.SetShaderParameter(StringNames.ColorDeep, ColorDeep);
+        _clipmap.Shader.SetShaderParameter(StringNames.ColorShallow, ColorShallow);
+        _clipmap.Shader.SetShaderParameter(StringNames.BeersLaw, BeersLaw);
+        _clipmap.Shader.SetShaderParameter(StringNames.DepthOffset, DepthOffset);
+        _clipmap.Shader.SetShaderParameter(StringNames.EdgeScale, EdgeScale);
+        _clipmap.Shader.SetShaderParameter(StringNames.Near, Near);
+        _clipmap.Shader.SetShaderParameter(StringNames.Far, Far);
+        _clipmap.Shader.SetShaderParameter(StringNames.EdgeColor, EdgeColor);
     }
 
     public void AddRippleEffect(float x, float y) {

--- a/addons/terrabrush/plugin.cfg
+++ b/addons/terrabrush/plugin.cfg
@@ -3,5 +3,5 @@
 name="TerraBrush"
 description=""
 author="spimort"
-version="0.5.1-alpha"
+version="0.5.2-alpha"
 script="Plugin.cs"


### PR DESCRIPTION
This PR solves a potential issue where implicitly converting strings to StringNames leads to garbage collection spikes. ([Reddit](https://www.reddit.com/r/godot/comments/17tqipk) / [Docs](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_basics.html#:~:text=Prefer%20using%20the%20exposed%20StringName%20in%20the%20PropertyName%2C%20MethodName%20and%20SignalName%20to%20avoid%20extra%20StringName%20allocations))
I've cached all the StringNames I could find in a static class.