### PR TITLE
Replace deprecated Image.Create with Image.CreateEmpty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+/.idea

--- a/addons/terrabrush/Scripts/CompatibilityScripts/CompatibilityScript0.4-alpha.cs
+++ b/addons/terrabrush/Scripts/CompatibilityScripts/CompatibilityScript0.4-alpha.cs
@@ -6,31 +6,37 @@ namespace TerraBrush;
 public static class CompatibilityScript_0_4_Alpha {
     public static async void Convert(TerraBrush terraBrush) {
         var hasWrongHeightmapFormat = terraBrush.TerrainZones?.Zones?.Any(x => x.HeightMapTexture.GetFormat() == Image.Format.Rf);
-        if (hasWrongHeightmapFormat.GetValueOrDefault()) {
-            var result = await DialogUtils.ShowConfirmDialog(terraBrush, "Convert", "Heightmaps has been created before the hole feature was a thing, which means that they are in the wrong format.\nThey must be converted in order for the hole feature to work.\nDo you want to convert them?");
+		if (!hasWrongHeightmapFormat.GetValueOrDefault()) return;
+		
+		var result = await DialogUtils.ShowConfirmDialog(terraBrush, "Convert", "Heightmaps has been created before the hole feature was a thing, which means that they are in the wrong format.\nThey must be converted in order for the hole feature to work.\nDo you want to convert them?");
+		if (!result) return;
+		
+		GD.Print("Starting heightmaps conversion...");
 
-            if (result) {
-                GD.Print("Starting heightmaps conversion...");
+		if (terraBrush.TerrainZones?.Zones != null)
+		{
+			foreach (var zone in terraBrush.TerrainZones.Zones)
+			{
+				if (zone.HeightMapTexture.GetFormat() != Image.Format.Rf) continue;
+				
+				var image = zone.HeightMapTexture.GetImage();
+				var newImage = Image.CreateEmpty(image.GetWidth(), image.GetHeight(), image.HasMipmaps(),
+					Image.Format.Rgf);
 
-                foreach (var zone in terraBrush.TerrainZones.Zones) {
-                    if (zone.HeightMapTexture.GetFormat() == Image.Format.Rf) {
-                        var image = zone.HeightMapTexture.GetImage();
-                        var newImage = Image.Create(image.GetWidth(), image.GetHeight(), image.HasMipmaps(), Image.Format.Rgf);
+				for (var x = 0; x < image.GetWidth(); x++)
+				{
+					for (var y = 0; y < image.GetWidth(); y++)
+					{
+						var pixel = image.GetPixel(x, y);
+						newImage.SetPixel(x, y, pixel);
+					}
+				}
 
-                        for (var x = 0; x < image.GetWidth(); x++) {
-                            for (var y = 0; y < image.GetWidth(); y++) {
-                                var pixel = image.GetPixel(x, y);
-                                newImage.SetPixel(x, y, pixel);
-                            }
-                        }
+				zone.HeightMapTexture.SetImage(newImage);
+				ResourceSaver.Save(zone.HeightMapTexture, zone.HeightMapTexture.ResourcePath);
+			}
+		}
 
-                        zone.HeightMapTexture.SetImage(newImage);
-                        ResourceSaver.Save(zone.HeightMapTexture, zone.HeightMapTexture.ResourcePath);
-                    }
-                }
-
-                GD.Print("Conversion done!");
-            }
-        }
-    }
+		GD.Print("Conversion done!");
+	}
 }

--- a/addons/terrabrush/Scripts/CompatibilityScripts/CompatibilityScript0.4-alpha.cs
+++ b/addons/terrabrush/Scripts/CompatibilityScripts/CompatibilityScript0.4-alpha.cs
@@ -18,7 +18,7 @@ public static class CompatibilityScript_0_4_Alpha {
 				if (zone.HeightMapTexture.GetFormat() != Image.Format.Rf) continue;
 				
 				var image = zone.HeightMapTexture.GetImage();
-				var newImage = Image.CreateEmpty(image.GetWidth(), image.GetHeight(), image.HasMipmaps(),
+				var newImage = GodotAgnostic.ImageCreateEmpty(image.GetWidth(), image.GetHeight(), image.HasMipmaps(),
 					Image.Format.Rgf);
 
 				for (var x = 0; x < image.GetWidth(); x++) {

--- a/addons/terrabrush/Scripts/CompatibilityScripts/CompatibilityScript0.4-alpha.cs
+++ b/addons/terrabrush/Scripts/CompatibilityScripts/CompatibilityScript0.4-alpha.cs
@@ -13,20 +13,16 @@ public static class CompatibilityScript_0_4_Alpha {
 		
 		GD.Print("Starting heightmaps conversion...");
 
-		if (terraBrush.TerrainZones?.Zones != null)
-		{
-			foreach (var zone in terraBrush.TerrainZones.Zones)
-			{
+		if (terraBrush.TerrainZones?.Zones != null) {
+			foreach (var zone in terraBrush.TerrainZones.Zones) {
 				if (zone.HeightMapTexture.GetFormat() != Image.Format.Rf) continue;
 				
 				var image = zone.HeightMapTexture.GetImage();
 				var newImage = Image.CreateEmpty(image.GetWidth(), image.GetHeight(), image.HasMipmaps(),
 					Image.Format.Rgf);
 
-				for (var x = 0; x < image.GetWidth(); x++)
-				{
-					for (var y = 0; y < image.GetWidth(); y++)
-					{
+				for (var x = 0; x < image.GetWidth(); x++) {
+					for (var y = 0; y < image.GetWidth(); y++) {
 						var pixel = image.GetPixel(x, y);
 						newImage.SetPixel(x, y, pixel);
 					}

--- a/addons/terrabrush/Scripts/CompatibilityScripts/GodotAgnostic.cs
+++ b/addons/terrabrush/Scripts/CompatibilityScripts/GodotAgnostic.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Godot;
+
+namespace TerraBrush;
+
+public static class GodotAgnostic {
+	// Still displays if a method is obsolete in case a newer method needs to be used again
+	private static void PrintObsoleteWarnings(MethodInfo method) {
+		foreach (var attribute in method.GetCustomAttributes().Where(a => a is ObsoleteAttribute)) {
+			GD.PushWarning($"{method.DeclaringType?.FullName ?? ""}.{method.Name} is obsolete: {attribute}");
+		}
+	}
+	
+	// Finds Image.Create or Image.CreateEmpty depending on the version of Godot and what's available
+	private static MethodInfo FindImageCreateEmpty() {
+		var imageType = typeof(Image);
+		
+		// Try to find the CreateEmpty method introduced in 4.3
+		var method = imageType.GetMethod("CreateEmpty");
+		
+		// If it can't be found, we are on Godot 4.2 and below
+		if (method == null) {
+			// Look for the Create method
+			method = imageType.GetMethod("Create");
+		}
+		
+		// Hopefully this is never the case...
+		if (method == null) {
+			GD.PrintErr("Couldn't find Godot.Image.CreateEmpty or Godot.Image.Create");
+		}
+		else {
+			PrintObsoleteWarnings(method);
+		}
+
+		return method;
+	}
+	public delegate Image ImageCreateEmptyMethod(int width, int height, bool useMipmaps, Image.Format format);
+
+	public static readonly ImageCreateEmptyMethod ImageCreateEmpty = FindImageCreateEmpty()?.CreateDelegate<ImageCreateEmptyMethod>();
+}

--- a/addons/terrabrush/Scripts/EditorResources/ZonesResource.cs
+++ b/addons/terrabrush/Scripts/EditorResources/ZonesResource.cs
@@ -31,7 +31,7 @@ public partial class ZonesResource : Resource {
     [Export] public ZoneResource[] Zones { get;set; }
 
     public void UpdateLockTexture() {
-        var images = Zones.Select(zone => zone.LockTexture?.GetImage() ?? Image.CreateEmpty(zone.HeightMapTexture.GetWidth(), zone.HeightMapTexture.GetHeight(), false, Image.Format.Rf)).ToArray();
+        var images = Zones.Select(zone => zone.LockTexture?.GetImage() ?? GodotAgnostic.ImageCreateEmpty(zone.HeightMapTexture.GetWidth(), zone.HeightMapTexture.GetHeight(), false, Image.Format.Rf)).ToArray();
 		
 		if (images.Length != 0) {
             _lockTextures.CreateFromImages(new Godot.Collections.Array<Image>(images));
@@ -136,7 +136,7 @@ public partial class ZonesResource : Resource {
 		var maxX = zonePositions.Max(x => Math.Abs(x.X));
 		var maxY = zonePositions.Max(x => Math.Abs(x.Y));
 
-		var zonesMap = Image.CreateEmpty((maxX * 2) + 1, (maxY * 2) + 1, false, Image.Format.Rf);
+		var zonesMap = GodotAgnostic.ImageCreateEmpty((maxX * 2) + 1, (maxY * 2) + 1, false, Image.Format.Rf);
 		zonesMap.Fill(new Color(-1, 0, 0, 0));
 		for (var i = 0; i < zonePositions.Length; i++) {
 			var position = zonePositions[i];

--- a/addons/terrabrush/Scripts/EditorResources/ZonesResource.cs
+++ b/addons/terrabrush/Scripts/EditorResources/ZonesResource.cs
@@ -38,8 +38,7 @@ public partial class ZonesResource : Resource {
         }
     }
 
-    public void UpdateHeightmaps()
-	{
+    public void UpdateHeightmaps() {
 		var images = Zones.Select(zone => zone.HeightMapTexture.GetImage()).ToArray();
 		if (images.Length != 0) {
             _heightmapTextures.CreateFromImages(new Godot.Collections.Array<Image>(images));

--- a/addons/terrabrush/Scripts/EditorResources/ZonesResource.cs
+++ b/addons/terrabrush/Scripts/EditorResources/ZonesResource.cs
@@ -31,17 +31,17 @@ public partial class ZonesResource : Resource {
     [Export] public ZoneResource[] Zones { get;set; }
 
     public void UpdateLockTexture() {
-        var images = Zones.Select(zone => zone.LockTexture?.GetImage() ?? Image.Create(zone.HeightMapTexture.GetWidth(), zone.HeightMapTexture.GetHeight(), false, Image.Format.Rf));
-
-        if (images.Any()) {
+        var images = Zones.Select(zone => zone.LockTexture?.GetImage() ?? Image.CreateEmpty(zone.HeightMapTexture.GetWidth(), zone.HeightMapTexture.GetHeight(), false, Image.Format.Rf)).ToArray();
+		
+		if (images.Length != 0) {
             _lockTextures.CreateFromImages(new Godot.Collections.Array<Image>(images));
         }
     }
 
-    public void UpdateHeightmaps() {
-        var images = Zones.Select(zone => zone.HeightMapTexture.GetImage());
-
-        if (images.Any()) {
+    public void UpdateHeightmaps()
+	{
+		var images = Zones.Select(zone => zone.HeightMapTexture.GetImage()).ToArray();
+		if (images.Length != 0) {
             _heightmapTextures.CreateFromImages(new Godot.Collections.Array<Image>(images));
         }
     }
@@ -65,17 +65,17 @@ public partial class ZonesResource : Resource {
     }
 
     public void UpdateFoliagesTextures() {
-        if (_foliagesTextures?.Length > 0) {
-            for (var i = 0; i < _foliagesTextures.Length; i++) {
-                UpdateFoliagesTextures(i);
-            }
-        }
-    }
+		if (_foliagesTextures?.Length <= 0) return;
+		
+		for (var i = 0; i < _foliagesTextures?.Length; i++) {
+			UpdateFoliagesTextures(i);
+		}
+	}
 
     public void UpdateFoliagesTextures(int foliageIndex) {
-        var images = Zones.Select(zone => zone.FoliagesTexture[foliageIndex].GetImage());
+        var images = Zones.Select(zone => zone.FoliagesTexture[foliageIndex].GetImage()).ToArray();
 
-        if (images.Any()) {
+        if (images.Length > 0) {
             _foliagesTextures[foliageIndex].CreateFromImages(new Godot.Collections.Array<Image>(images));
         }
     }
@@ -127,7 +127,7 @@ public partial class ZonesResource : Resource {
     }
 
     private void SaveImageResource(ImageTexture image) {
-        if (!string.IsNullOrWhiteSpace(image.ResourcePath) && Godot.FileAccess.FileExists(image.ResourcePath)) {
+        if (!string.IsNullOrWhiteSpace(image.ResourcePath) && FileAccess.FileExists(image.ResourcePath)) {
             ResourceSaver.Save(image, image.ResourcePath);
         }
     }
@@ -137,9 +137,9 @@ public partial class ZonesResource : Resource {
 		var maxX = zonePositions.Max(x => Math.Abs(x.X));
 		var maxY = zonePositions.Max(x => Math.Abs(x.Y));
 
-		var zonesMap = Image.Create((maxX * 2) + 1, (maxY * 2) + 1, false, Image.Format.Rf);
+		var zonesMap = Image.CreateEmpty((maxX * 2) + 1, (maxY * 2) + 1, false, Image.Format.Rf);
 		zonesMap.Fill(new Color(-1, 0, 0, 0));
-		for (var i = 0; i < zonePositions.Count(); i++) {
+		for (var i = 0; i < zonePositions.Length; i++) {
 			var position = zonePositions[i];
 			zonesMap.SetPixel(position.X + maxX, position.Y + maxY, new Color(i, 0, 0, 0));
 		}

--- a/addons/terrabrush/Scripts/ZoneUtils.cs
+++ b/addons/terrabrush/Scripts/ZoneUtils.cs
@@ -11,7 +11,7 @@ public static class ZoneUtils {
     private const string SnowFileName = "Snow_{0}_{1}.res";
 
     public static ImageTexture CreateLockImage(int zoneSize, Vector2I zonePosition, bool lockAll = false) {
-        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rf);
+        var image = GodotAgnostic.ImageCreateEmpty(zoneSize, zoneSize, false, Image.Format.Rf);
         if (lockAll) {
             image.Fill(Colors.White);
         }
@@ -20,12 +20,12 @@ public static class ZoneUtils {
     }
 
     public static ImageTexture CreateHeightmapImage(int zoneSize, Vector2I zonePosition, string dataPath) {
-        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgf);
+        var image = GodotAgnostic.ImageCreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgf);
         return GetImageTextureResource(image, string.Format(HeightmapFileName, zonePosition.X, zonePosition.Y), dataPath);
     }
 
     public static ImageTexture CreateSplatmapImage(int zoneSize, Vector2I zonePosition, int splatmapIndex, string dataPath) {
-        var splatmapImage = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var splatmapImage = GodotAgnostic.ImageCreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
 
         if (splatmapIndex == 0) {
             splatmapImage.Fill(new Color(1, 0, 0, 0));
@@ -37,24 +37,24 @@ public static class ZoneUtils {
     }
 
     public static ImageTexture CreateFoliageImage(int zoneSize, Vector2I zonePosition, int foliageIndex, string dataPath) {
-        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var image = GodotAgnostic.ImageCreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         return GetImageTextureResource(image, string.Format(FoliageFileName, zonePosition.X, zonePosition.Y, foliageIndex), dataPath);
     }
 
     public static ImageTexture CreateObjectImage(int zoneSize, Vector2I zonePosition, int objectIndex, string dataPath) {
-        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var image = GodotAgnostic.ImageCreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         return GetImageTextureResource(image, string.Format(ObjectFileName, zonePosition.X, zonePosition.Y, objectIndex), dataPath);
     }
 
     public static ImageTexture CreateWaterImage(int zoneSize, Vector2I zonePosition, string dataPath) {
-        var waterImage = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var waterImage = GodotAgnostic.ImageCreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         waterImage.Fill(new Color(0, 0.5f, 0.5f, 1));
 
         return GetImageTextureResource(waterImage, string.Format(WaterFileName, zonePosition.X, zonePosition.Y), dataPath);
     }
 
     public static ImageTexture CreateSnowImage(int zoneSize, Vector2I zonePosition, string dataPath) {
-        var snowImage = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var snowImage = GodotAgnostic.ImageCreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         return GetImageTextureResource(snowImage, string.Format(SnowFileName, zonePosition.X, zonePosition.Y), dataPath);
     }
 

--- a/addons/terrabrush/Scripts/ZoneUtils.cs
+++ b/addons/terrabrush/Scripts/ZoneUtils.cs
@@ -11,7 +11,7 @@ public static class ZoneUtils {
     private const string SnowFileName = "Snow_{0}_{1}.res";
 
     public static ImageTexture CreateLockImage(int zoneSize, Vector2I zonePosition, bool lockAll = false) {
-        var image = Image.Create(zoneSize, zoneSize, false, Image.Format.Rf);
+        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rf);
         if (lockAll) {
             image.Fill(Colors.White);
         }
@@ -20,12 +20,12 @@ public static class ZoneUtils {
     }
 
     public static ImageTexture CreateHeightmapImage(int zoneSize, Vector2I zonePosition, string dataPath) {
-        var image = Image.Create(zoneSize, zoneSize, false, Image.Format.Rgf);
+        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgf);
         return GetImageTextureResource(image, string.Format(HeightmapFileName, zonePosition.X, zonePosition.Y), dataPath);
     }
 
     public static ImageTexture CreateSplatmapImage(int zoneSize, Vector2I zonePosition, int splatmapIndex, string dataPath) {
-        var splatmapImage = Image.Create(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var splatmapImage = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
 
         if (splatmapIndex == 0) {
             splatmapImage.Fill(new Color(1, 0, 0, 0));
@@ -37,24 +37,24 @@ public static class ZoneUtils {
     }
 
     public static ImageTexture CreateFoliageImage(int zoneSize, Vector2I zonePosition, int foliageIndex, string dataPath) {
-        var image = Image.Create(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         return GetImageTextureResource(image, string.Format(FoliageFileName, zonePosition.X, zonePosition.Y, foliageIndex), dataPath);
     }
 
     public static ImageTexture CreateObjectImage(int zoneSize, Vector2I zonePosition, int objectIndex, string dataPath) {
-        var image = Image.Create(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var image = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         return GetImageTextureResource(image, string.Format(ObjectFileName, zonePosition.X, zonePosition.Y, objectIndex), dataPath);
     }
 
     public static ImageTexture CreateWaterImage(int zoneSize, Vector2I zonePosition, string dataPath) {
-        var waterImage = Image.Create(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var waterImage = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         waterImage.Fill(new Color(0, 0.5f, 0.5f, 1));
 
         return GetImageTextureResource(waterImage, string.Format(WaterFileName, zonePosition.X, zonePosition.Y), dataPath);
     }
 
     public static ImageTexture CreateSnowImage(int zoneSize, Vector2I zonePosition, string dataPath) {
-        var snowImage = Image.Create(zoneSize, zoneSize, false, Image.Format.Rgba8);
+        var snowImage = Image.CreateEmpty(zoneSize, zoneSize, false, Image.Format.Rgba8);
         return GetImageTextureResource(snowImage, string.Format(SnowFileName, zonePosition.X, zonePosition.Y), dataPath);
     }
 


### PR DESCRIPTION
- Replace usage of Image.Create with Image.CreateEmpty since Image.Create is now marked as Obsolete/Deprecated

Additional changes (I'll undo/remove these as needed):
- Enumerate some Zone queries to an array to avoid multiple enumerations
- Additional null checks
- Some personal decisions to invert if statements to avoid some nesting