### PR TITLE
Added tooltips for 'Textures', 'Foliage' and 'Objects' (Terrain Editor)

### DIFF
--- a/addons/terrabrush/Scripts/CustomContentLoader.cs
+++ b/addons/terrabrush/Scripts/CustomContentLoader.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Godot;
 
 namespace TerraBrush;
@@ -62,9 +63,13 @@ public static class CustomContentLoader {
                 var dockPreviewButton = texturePreviewPrefab.Instantiate<DockPreviewButton>();
                 dockPreviewButton.IconType = useCircleIcon ? IconType.Circle : IconType.Square;
                 dockPreviewButton.Margin = 10;
+                dockPreviewButton.SetTextureImage(textureSet.AlbedoTexture);
+                dockPreviewButton.TooltipText = !string.IsNullOrEmpty(textureSet.Name)
+                                                ? textureSet.Name
+                                                : $"Texture {i + 1}";
+
                 parentNode.AddChild(dockPreviewButton);
 
-                dockPreviewButton.SetTextureImage(textureSet.AlbedoTexture);
 
                 var currentIndex = i;
                 dockPreviewButton.OnSelect = () => {
@@ -84,7 +89,6 @@ public static class CustomContentLoader {
                     var dockPreviewButton = foliagePreviewPrefab.Instantiate<DockPreviewButton>();
                     dockPreviewButton.IconType = useCircleIcon ? IconType.Circle : IconType.Square;
                     dockPreviewButton.Margin = 5;
-                    parentNode.AddChild(dockPreviewButton);
 
                     if (foliage.Definition?.MeshMaterial == null && foliage.Definition?.AlbedoTextures?.Length == 0 && foliage.Definition.Mesh != null) {
                         dockPreviewButton.LoadResourcePreview(foliage.Definition.Mesh);
@@ -93,6 +97,12 @@ public static class CustomContentLoader {
                     } else if (foliage.Definition?.AlbedoTextures?.Length > 0) {
                         dockPreviewButton.LoadResourcePreview(foliage.Definition.AlbedoTextures[0]);
                     }
+
+                    dockPreviewButton.TooltipText = !string.IsNullOrEmpty(foliage.Definition?.Mesh?.ResourcePath)
+                                                    ? Path.GetFileName(foliage.Definition.Mesh.ResourcePath)
+                                                    : $"Foliage {i + 1}";
+
+                    parentNode.AddChild(dockPreviewButton);
 
                     var currentIndex = i;
                     dockPreviewButton.OnSelect = () => {
@@ -114,10 +124,26 @@ public static class CustomContentLoader {
                     var dockPreviewButton = objectPreviewPrefab.Instantiate<DockPreviewButton>();
                     dockPreviewButton.IconType = useCircleIcon ? IconType.Circle : IconType.Square;
                     dockPreviewButton.Margin = 5;
-                    parentNode.AddChild(dockPreviewButton);
 
                     var meshResource = (Resource) (objectItem.Definition?.ObjectScenes?.Length > 0 ? objectItem.Definition?.ObjectScenes[0] : objectItem.Definition?.LODMeshes[0].Meshes[0].Mesh);
                     dockPreviewButton.LoadResourcePreview(meshResource);
+
+                    var packedScenes = objectItem.Definition?.ObjectScenes;
+                    var tooltipText = $"Object {i + 1}";
+                    if (packedScenes?.Length > 0) {
+                        var sceneNames = packedScenes
+                            .Where(scene => scene != null)
+                            .Select(scene => Path.GetFileName(scene.ResourcePath))
+                            .Where(name => !string.IsNullOrEmpty(name));
+                        var joinedNames = string.Join(", ", sceneNames);
+                        if (!string.IsNullOrEmpty(joinedNames)) {
+                            tooltipText = joinedNames;
+                        }
+                    }
+
+                    dockPreviewButton.TooltipText = tooltipText;
+
+                    parentNode.AddChild(dockPreviewButton);
 
                     var currentIndex = i;
                     dockPreviewButton.OnSelect = () => {

--- a/addons/terrabrush/Scripts/TerrainControlDock.cs
+++ b/addons/terrabrush/Scripts/TerrainControlDock.cs
@@ -1,5 +1,7 @@
 #if TOOLS
 using Godot;
+using System.IO;
+using System.Linq;
 
 namespace TerraBrush;
 
@@ -123,6 +125,19 @@ public partial class TerrainControlDock : Control {
             SetSelectedTextureIndex(index);
         });
 
+        var textureSets = TerraBrush?.TextureSets?.TextureSets;
+        if (textureSets != null) {
+            foreach (var texturePreview in _texturesContainer.GetChildren().OfType<DockPreviewButton>()) {
+                int index = texturePreview.GetIndex();
+                if (index < 0 || index >= textureSets.Length) {
+                    continue;
+                }
+
+                var textureSet = textureSets[index];
+                texturePreview.TooltipText = textureSet.Name ?? $"Texture {index + 1}";
+            }
+        }
+
         if (_texturesContainer.GetChildCount() > 0 && _selectedTextureIndex == null) {
             _selectedTextureIndex = 0;
         }
@@ -151,6 +166,27 @@ public partial class TerrainControlDock : Control {
         CustomContentLoader.AddFoliagesPreviewToParent(TerraBrush, _foliagesContainer, index => {
             SetSelectedFoliageIndex(index);
         });
+
+        var foliages = TerraBrush?.Foliages;
+        if (foliages != null) {
+
+            foreach (var foliagePreview in _foliagesContainer.GetChildren().OfType<DockPreviewButton>()) {
+                int index = foliagePreview.GetIndex();
+                if (index < 0 || index >= foliages.Length) {
+                    continue;
+                }
+
+                var foliage = foliages[index];
+                string tooltipText = $"Foliage {index + 1}";
+
+                var meshPath = foliage?.Definition?.Mesh?.ResourcePath;
+                if (!string.IsNullOrEmpty(meshPath)) {
+                    tooltipText = Path.GetFileName(meshPath);
+                }
+
+                foliagePreview.TooltipText = tooltipText;
+            }
+        }
 
         if (TerraBrush.Foliages?.Length > 0 && _selectedFoliageIndex == null) {
             _selectedFoliageIndex = 0;
@@ -181,6 +217,34 @@ public partial class TerrainControlDock : Control {
         CustomContentLoader.AddObjectsPreviewToParent(TerraBrush, _objectsContainer, index => {
             SetSelectedObjectIndex(index);
         });
+
+        var objects = TerraBrush?.Objects;
+        if (objects != null) {
+            foreach (var objectPreview in _objectsContainer.GetChildren().OfType<DockPreviewButton>()) {
+                int index = objectPreview.GetIndex();
+                if (index < 0 || index >= objects.Length) {
+                    continue;
+                }
+
+                var objectItem = objects[index];
+                string tooltipText = $"Object {index + 1}";
+
+                var packedScenes = objectItem?.Definition?.ObjectScenes;
+                if (packedScenes?.Length > 0) {
+                    var sceneNames = packedScenes
+                        .Where(scene => scene != null)
+                        .Select(scene => Path.GetFileName(scene.ResourcePath))
+                        .Where(name => !string.IsNullOrEmpty(name));
+
+                    var joinedNames = string.Join(", ", sceneNames);
+                    if (!string.IsNullOrEmpty(joinedNames)) {
+                        tooltipText = joinedNames;
+                    }
+                }
+
+                objectPreview.TooltipText = tooltipText;
+            }
+        }
 
         if (TerraBrush.Objects?.Length > 0 && _selectedObjectIndex == null) {
             _selectedObjectIndex = 0;

--- a/addons/terrabrush/Scripts/TerrainControlDock.cs
+++ b/addons/terrabrush/Scripts/TerrainControlDock.cs
@@ -1,7 +1,5 @@
 #if TOOLS
 using Godot;
-using System.IO;
-using System.Linq;
 
 namespace TerraBrush;
 
@@ -125,19 +123,6 @@ public partial class TerrainControlDock : Control {
             SetSelectedTextureIndex(index);
         });
 
-        var textureSets = TerraBrush?.TextureSets?.TextureSets;
-        if (textureSets != null) {
-            foreach (var texturePreview in _texturesContainer.GetChildren().OfType<DockPreviewButton>()) {
-                int index = texturePreview.GetIndex();
-                if (index < 0 || index >= textureSets.Length) {
-                    continue;
-                }
-
-                var textureSet = textureSets[index];
-                texturePreview.TooltipText = textureSet.Name ?? $"Texture {index + 1}";
-            }
-        }
-
         if (_texturesContainer.GetChildCount() > 0 && _selectedTextureIndex == null) {
             _selectedTextureIndex = 0;
         }
@@ -166,27 +151,6 @@ public partial class TerrainControlDock : Control {
         CustomContentLoader.AddFoliagesPreviewToParent(TerraBrush, _foliagesContainer, index => {
             SetSelectedFoliageIndex(index);
         });
-
-        var foliages = TerraBrush?.Foliages;
-        if (foliages != null) {
-
-            foreach (var foliagePreview in _foliagesContainer.GetChildren().OfType<DockPreviewButton>()) {
-                int index = foliagePreview.GetIndex();
-                if (index < 0 || index >= foliages.Length) {
-                    continue;
-                }
-
-                var foliage = foliages[index];
-                string tooltipText = $"Foliage {index + 1}";
-
-                var meshPath = foliage?.Definition?.Mesh?.ResourcePath;
-                if (!string.IsNullOrEmpty(meshPath)) {
-                    tooltipText = Path.GetFileName(meshPath);
-                }
-
-                foliagePreview.TooltipText = tooltipText;
-            }
-        }
 
         if (TerraBrush.Foliages?.Length > 0 && _selectedFoliageIndex == null) {
             _selectedFoliageIndex = 0;
@@ -217,34 +181,6 @@ public partial class TerrainControlDock : Control {
         CustomContentLoader.AddObjectsPreviewToParent(TerraBrush, _objectsContainer, index => {
             SetSelectedObjectIndex(index);
         });
-
-        var objects = TerraBrush?.Objects;
-        if (objects != null) {
-            foreach (var objectPreview in _objectsContainer.GetChildren().OfType<DockPreviewButton>()) {
-                int index = objectPreview.GetIndex();
-                if (index < 0 || index >= objects.Length) {
-                    continue;
-                }
-
-                var objectItem = objects[index];
-                string tooltipText = $"Object {index + 1}";
-
-                var packedScenes = objectItem?.Definition?.ObjectScenes;
-                if (packedScenes?.Length > 0) {
-                    var sceneNames = packedScenes
-                        .Where(scene => scene != null)
-                        .Select(scene => Path.GetFileName(scene.ResourcePath))
-                        .Where(name => !string.IsNullOrEmpty(name));
-
-                    var joinedNames = string.Join(", ", sceneNames);
-                    if (!string.IsNullOrEmpty(joinedNames)) {
-                        tooltipText = joinedNames;
-                    }
-                }
-
-                objectPreview.TooltipText = tooltipText;
-            }
-        }
 
         if (TerraBrush.Objects?.Length > 0 && _selectedObjectIndex == null) {
             _selectedObjectIndex = 0;

--- a/addons/terrabrush/plugin.cfg
+++ b/addons/terrabrush/plugin.cfg
@@ -3,5 +3,5 @@
 name="TerraBrush"
 description=""
 author="spimort"
-version="0.10.0-alpha"
+version="0.10.1-alpha"
 script="Plugin.cs"


### PR DESCRIPTION
Hi @spimort 

I added tooltips for 'Textures', 'Foliage' and 'Objects' items in the Terrain Editor, mainly to help me with very similar groups of textures for my game, I hope this can be useful. :)

Visual examples in the demo project:

Texture names:  
![Godot_v4 3-stable_mono_win64_ryY5SRlT9A](https://github.com/user-attachments/assets/49f115ba-09d5-4f46-997e-037fff604c7e)

Foliage:  
![Godot_v4 3-stable_mono_win64_VUYA1Y460e](https://github.com/user-attachments/assets/78dc8901-9067-4ac1-8e3f-5e2177e30b57)

Objects:  
![Godot_v4 3-stable_mono_win64_9rJctr9NaB](https://github.com/user-attachments/assets/4232198f-b7ff-46f0-a30b-9482208873d1)


