### PR TITLE
Add the triplanar option to prevent texture stretching

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ For example, if you add a new texture, add foliage, add an object, add a water d
 |TextureSetResource[x].NormalTexture|The normal map texture of the set.|
 |TextureSetResource[x].RoughnessTexture|The roughness texture of the set.|
 |TextureSetResource[x].TextureDetail|This will determine how often your texture will be repeated on the terrain. A higher value means more repetitions. The default value is -1 to take the global TextureDetail of the terrain.|
+|TextureSetResource[x].Triplanar|This option prevents texture stretching using a triplanar algorithm. This option is available per texture for better control over performance.|
 |Texture Detail|This will determine how often your textures will be repeated on the terrain. A higher value means more repetitions. The default value is 20.|
 |Use Anti Tile|This will determine if the textures will use an Anti Tile algorithm.|
 |Height Blend Factor|The intensity (contrast) of the texture blending when using heightmaps/bumpmaps. 0 will use classic linear blending. The default value is 10. Negative or exaggerated values may produce interesting artistic effects.

--- a/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader.gdshader
+++ b/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader.gdshader
@@ -4,15 +4,29 @@ render_mode cull_back,blend_mix,depth_draw_opaque,diffuse_burley,specular_schlic
 #include "res://addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader_include.gdshaderinc"
 
 varying vec3 _worldVertex;
+varying vec3 _triplanarPos;
+varying vec3 _triplanarPowerNormal;
 
 void vertex() {
 	_worldVertex = vec3(0);
-	calculateHeightmapVertex(MODEL_MATRIX, COLOR, VERTEX, NORMAL, _worldVertex);
+	_triplanarPos = vec3(0);
+	_triplanarPowerNormal = vec3(0);
+	calculateHeightmapVertex(
+		MODEL_MATRIX, 
+		COLOR, 
+		VERTEX, 
+		NORMAL, 
+		_worldVertex, 
+		_triplanarPos, 
+		_triplanarPowerNormal
+	);
 }
 
 void fragment() {
 	calculateHeightmapFragment(
 		_worldVertex,
+		_triplanarPos,
+		_triplanarPowerNormal,
 		ALBEDO,
 		NORMAL_MAP,
 		ROUGHNESS,

--- a/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader_include.gdshaderinc
+++ b/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader_include.gdshaderinc
@@ -23,6 +23,8 @@ uniform float BlendFactor;
 uniform bool NearestFilter = false;
 uniform int AlbedoAlphaChannelUsage = 0; // None = 0; Roughness = 1; Height = 2
 uniform int NormalAlphaChannelUsage = 0; // None = 0; Roughness = 1; Height = 2
+uniform bool Triplanar = true;
+uniform int[100] TexturesTriplanar;
 
 const int ALPHA_CHANNEL_USAGE_NONE = 0;
 const int ALPHA_CHANNEL_USAGE_ROUGHNESS = 1;
@@ -79,11 +81,11 @@ vec4 texture_array_antitile(sampler2DArray texLinear, sampler2DArray texNearest,
 		col0 = texture(texLinear, uv);
 		col1 = texture(texLinear, uv2);
 	}
-	
+
 	if (isNormal) {
 		vec3 n = unpack_normal(col1);
 		n.xz = rotate(n.xz, cosa, -sina);
-		col1 = pack_normal(n, col1.a);		
+		col1 = pack_normal(n, col1.a);
 	}
 
 	// Periodically alternate between the two versions using a warped checker pattern
@@ -100,12 +102,13 @@ void calculateHeightmapVertex(
 	inout vec4 color,
 	inout vec3 vertex,
 	inout vec3 normal,
-	inout vec3 worldVertex
+	inout vec3 worldVertex,
+	inout vec3 triplanarPos,
+	inout vec3 triplanarPowerNormal
 ) {
 	calculateVertex(modelMatrix, color, vertex, worldVertex);
 
 	vec3 zoneUV = calculateZoneUV(worldVertex);
-
 	const vec3 off = vec3(1.0, 1.0, 0.0);
 	float hL = calculateVertexHeight(color, vertex, worldVertex, -off.xz);
 	float hR = calculateVertexHeight(color, vertex, worldVertex, off.xz);
@@ -115,6 +118,13 @@ void calculateHeightmapVertex(
 
 	vec4 waterTexture = texture(WaterTextures, zoneUV);
 	vertex.y -= waterTexture.r * WaterFactor;
+
+	if (Triplanar) {
+		triplanarPowerNormal = pow(abs(normal), vec3(150.0));
+		triplanarPos = vec3(worldVertex.x, vertex.y, worldVertex.z);
+		triplanarPowerNormal /= dot(triplanarPowerNormal, vec3(1.0));
+		triplanarPos *= vec3(1.0, -1.0, 1.0);
+	}
 }
 
 float getChannelValue(int currentChannel, vec4 currentSplatmap) {
@@ -133,8 +143,35 @@ vec4 fillVec4WithFilterTexture(vec3 textureUV, sampler2DArray linearTextures, sa
 	}
 }
 
+vec4 triplanarTexture(float textureIndex, sampler2DArray linearTextures, sampler2DArray nearestTextures, bool isNormal, vec3 triplanarWeights, vec3 triplanarPos) {
+	vec4 samp = vec4(0.0);
+	float textureDetail = (float(TexturesDetail[int(textureIndex)]) * (1.0 / ZonesSize));;
+
+	samp += fillVec4WithFilterTexture(vec3(triplanarPos.xy * textureDetail, textureIndex), linearTextures, nearestTextures, isNormal) * triplanarWeights.z;
+	samp += fillVec4WithFilterTexture(vec3(triplanarPos.xz * textureDetail, textureIndex), linearTextures, nearestTextures, isNormal) * triplanarWeights.y;
+	samp += fillVec4WithFilterTexture(vec3((triplanarPos.zy * vec2(-1.0, 1.0)) * textureDetail, textureIndex), linearTextures, nearestTextures, isNormal) * triplanarWeights.x;
+	return samp;
+}
+
+vec4 getVec4Texture(
+	vec3 textureUV,
+	vec3 triplanarPos,
+	vec3 triplanarPowerNormal,
+	sampler2DArray linearTextures,
+	sampler2DArray nearestTextures,
+	bool isNormal
+) {
+	if (TexturesTriplanar[int(textureUV.z)] == 1) {
+		return triplanarTexture(textureUV.z, linearTextures, nearestTextures, isNormal, triplanarPowerNormal, triplanarPos);
+	} else {
+		return fillVec4WithFilterTexture(textureUV, linearTextures, nearestTextures, isNormal);
+	}
+}
+
 void calculateHeightmapFragment(
 	vec3 worldVertex,
+	vec3 triplanarPos,
+	vec3 triplanarPowerNormal,
 	inout vec3 albedo,
 	inout vec3 normalMap,
 	inout float roughness,
@@ -164,19 +201,19 @@ void calculateHeightmapFragment(
 		vec4 currentRoughness = vec4(0);
 		vec4 currentHeight = vec4(0);
 
-		currentTexture = fillVec4WithFilterTexture(textureUV, Textures, TexturesNearest, false);
+		currentTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Textures, TexturesNearest, false);
 		currentRoughness = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS));
 		currentHeight = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT));
 		if (HasNormalTextures) {
-			currentNormal = fillVec4WithFilterTexture(textureUV, Normals, NormalsNearest, true);
+			currentNormal = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Normals, NormalsNearest, true);
 			currentRoughness = max(currentRoughness, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_ROUGHNESS && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS)));
 			currentHeight = max(currentHeight, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_HEIGHT && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT)));
 		}
 		if (HasRoughnessTextures) {
-			currentRoughness = fillVec4WithFilterTexture(textureUV, RoughnessTextures, RoughnessTexturesNearest, false);
+			currentRoughness = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, RoughnessTextures, RoughnessTexturesNearest, false);
 		}
 		if (HasHeightTextures) {
-			currentHeight = fillVec4WithFilterTexture(textureUV, HeightTextures, HeightTexturesNearest, false);
+			currentHeight = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, HeightTextures, HeightTexturesNearest, false);
 		}
 
 		vec4 currentSplatmap = texture(Splatmaps, splatmapUV);

--- a/addons/terrabrush/Scripts/EditorResources/TextureSetResource.cs
+++ b/addons/terrabrush/Scripts/EditorResources/TextureSetResource.cs
@@ -48,6 +48,7 @@ public partial class TextureSetResource : Resource {
     [Export] public Texture2D RoughnessTexture { get;set; }
     [Export] public Texture2D HeightTexture { get;set; }
     [Export] public int TextureDetail { get;set; } = -1;
+    [Export] public bool Triplanar { get;set; }
 
     private Texture2D FindTexture(string fileHint, string directory, string[] directoryFiles) {
         var files = directoryFiles.Where(file => file.Contains(fileHint, System.StringComparison.InvariantCultureIgnoreCase) && !file.EndsWith(".import"));

--- a/addons/terrabrush/Scripts/StringNames.cs
+++ b/addons/terrabrush/Scripts/StringNames.cs
@@ -76,4 +76,6 @@ internal static class StringNames {
     public static readonly StringName NormalAlphaChannelUsage = "NormalAlphaChannelUsage";
     public static readonly StringName OffsetPosition = "OffsetPosition";
     public static readonly StringName Resolution = "Resolution";
+    public static readonly StringName Triplanar = "Triplanar";
+    public static readonly StringName TexturesTriplanar = "TexturesTriplanar";
 }

--- a/addons/terrabrush/Scripts/Terrain.cs
+++ b/addons/terrabrush/Scripts/Terrain.cs
@@ -242,6 +242,8 @@ public partial class Terrain : Node3D {
         if (this.TextureSets?.TextureSets?.Length > 0) {
             var textureArray = Utils.TexturesToTextureArray(this.TextureSets.TextureSets.Select(x => x.AlbedoTexture));
             Clipmap.Shader.SetShaderParameter(StringNames.TexturesDetail, TextureSets.TextureSets.Select(x => x.TextureDetail <= 0 ? TextureDetail : x.TextureDetail).ToArray());
+            Clipmap.Shader.SetShaderParameter(StringNames.Triplanar, TextureSets.TextureSets.Any(x => x.Triplanar));
+            Clipmap.Shader.SetShaderParameter(StringNames.TexturesTriplanar, TextureSets.TextureSets.Select(x => x.Triplanar ? 1 : 0).ToArray());
             Clipmap.Shader.SetShaderParameter($"Textures{filterParamName}", textureArray);
             Clipmap.Shader.SetShaderParameter(StringNames.NumberOfTextures, textureArray.GetLayers());
 

--- a/addons/terrabrush/plugin.cfg
+++ b/addons/terrabrush/plugin.cfg
@@ -3,5 +3,5 @@
 name="TerraBrush"
 description=""
 author="spimort"
-version="0.11.3-alpha"
+version="0.11.4-alpha"
 script="Plugin.cs"


### PR DESCRIPTION
This feature adds an option on each texture set to enable or not the triplanar algorithm.

**Note that this feature introduces a breaking change for the projects using a custom shader.**
New parameters need to be provided to the original shader so it works with the triplanar thing (varying variables)