### PR TITLE
Implement a SharpTransition option for the splatmap when texture painting

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ For example, if you add a new texture, add foliage, add an object, add a water d
 |Nearest Texture Filter|Use nearest texture filter instead of linear filter.|
 |Albedo Alpha Channel Usage|Allow the use of the alpha channel of the albedo texture for either roughness or height. The default value is none.|
 |Normal Alpha Channel Usage|Allow the use of the alpha channel of the normal texture for either roughness or height. The default value is none.|
+|Use Sharp Transitions|Use sharp transition between textures instead of blending them together. This will use the most dominant texture.|
 |**Foliage**||
 |Foliages|An array of FoliageResource. **Make sure to hit the update terrain button when you modify this and the terrain has already been created**.|
 |FoliageResource[x].Definition|The definition of the foliage. Create a **FoliageDefinitionResource** to use it. You can create a resource of this definition to reuse it in other terrain.|

--- a/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader_include.gdshaderinc
+++ b/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader_include.gdshaderinc
@@ -25,6 +25,7 @@ uniform int AlbedoAlphaChannelUsage = 0; // None = 0; Roughness = 1; Height = 2
 uniform int NormalAlphaChannelUsage = 0; // None = 0; Roughness = 1; Height = 2
 uniform bool Triplanar = true;
 uniform int[100] TexturesTriplanar;
+uniform bool UseSharpTransitions = false;
 
 const int ALPHA_CHANNEL_USAGE_NONE = 0;
 const int ALPHA_CHANNEL_USAGE_ROUGHNESS = 1;
@@ -168,6 +169,63 @@ vec4 getVec4Texture(
 	}
 }
 
+int getChannelIndex(int textureIndex) {
+    return textureIndex % 4;
+}
+
+int getSplatmapIndex(int textureIndex) {
+    return textureIndex / 4;
+}
+
+int findDominantTextureIndex(vec3 worldVertex) {
+    vec3 zoneUV = calculateZoneUV(worldVertex);
+    float maxValue = -1.0;
+    int dominantTextureIndex = 0;
+
+    for (int i = 0; i < NumberOfTextures; i++) {
+        int splatmapIdx = getSplatmapIndex(i);
+        int channelIdx = getChannelIndex(i);
+
+        vec3 textureZoneUV = zoneUV;
+        if (Resolution > 1.0) {
+            textureZoneUV = calculateZoneUVResolution(worldVertex, false);
+        }
+
+        vec3 splatmapUV = vec3(textureZoneUV.x, textureZoneUV.y,
+                             float(splatmapIdx) + (textureZoneUV.z * ceil(float(NumberOfTextures) / 4.0)));
+
+        vec4 currentSplatmap = texture(Splatmaps, splatmapUV);
+        float value = currentSplatmap[channelIdx];
+
+        if (HasHeightTextures || AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT ||
+            NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT) {
+            int textureDetail = TexturesDetail[i];
+            vec2 worldVertexUV = worldVertex.xz * (float(textureDetail) * (1.0 / ZonesSize));
+            vec3 textureUV = vec3(worldVertexUV.x, worldVertexUV.y, float(i));
+
+            vec4 heightSample = vec4(0.0);
+            if (HasHeightTextures) {
+                heightSample = getVec4Texture(textureUV, vec3(0.0), vec3(0.0),
+                                        HeightTextures, HeightTexturesNearest, false);
+            } else {
+                vec4 albedoSample = getVec4Texture(textureUV, vec3(0.0), vec3(0.0),
+                                          Textures, TexturesNearest, false);
+                heightSample.r = albedoSample.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT);
+            }
+
+            float heightInfluence = contrast(BlendFactor * 2.0, heightSample.r) * 0.2;
+            value += heightInfluence;
+        }
+
+        if (value > maxValue) {
+            maxValue = value;
+            dominantTextureIndex = i;
+        }
+    }
+
+    return dominantTextureIndex;
+}
+
 void calculateHeightmapFragment(
 	vec3 worldVertex,
 	vec3 triplanarPos,
@@ -178,89 +236,125 @@ void calculateHeightmapFragment(
 	inout float alpha,
 	inout float alphaScissorThreshold
 ) {
-	vec4 resultTexture = vec4(0.0);
-	vec4 resultNormal = vec4(0.0);
-	vec4 resultRoughness = vec4(0.0);
+    if (UseSharpTransitions) {
+        int dominantTextureIndex = findDominantTextureIndex(worldVertex);
 
-	vec3 zoneUV = calculateZoneUV(worldVertex);
+        int textureDetail = TexturesDetail[dominantTextureIndex];
+        vec2 worldVertexUV = worldVertex.xz * (float(textureDetail) * (1.0 / ZonesSize));
+        vec3 textureUV = vec3(worldVertexUV.x, worldVertexUV.y, float(dominantTextureIndex));
 
-	int currentChannel = 0;
-	float channelSum = 0.0;
-	for (int i = 0; i < NumberOfTextures; i++) {
-		int textureDetail = TexturesDetail[i];
-		vec2 worldVertexUV = worldVertex.xz * (float(textureDetail) * (1.0 / ZonesSize));
-		vec3 textureUV = vec3(worldVertexUV.x, worldVertexUV.y, float(i));
-		vec3 textureZoneUV = zoneUV;
-		if (Resolution > 1.0) {
-			textureZoneUV = calculateZoneUVResolution(worldVertex, false);
-		}
-		vec3 splatmapUV = vec3(textureZoneUV.x, textureZoneUV.y, floor(float(i/4)) + (textureZoneUV.z * ceil(float(NumberOfTextures) / 4.0)));
+        vec4 dominantTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal,
+                                           Textures, TexturesNearest, false);
 
-		vec4 currentTexture = vec4(0);
-		vec4 currentNormal = vec4(0);
-		vec4 currentRoughness = vec4(0);
-		vec4 currentHeight = vec4(0);
+        albedo = dominantTexture.rgb;
 
-		currentTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Textures, TexturesNearest, false);
-		currentRoughness = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS));
-		currentHeight = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT));
-		if (HasNormalTextures) {
-			currentNormal = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Normals, NormalsNearest, true);
-			currentRoughness = max(currentRoughness, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_ROUGHNESS && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS)));
-			currentHeight = max(currentHeight, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_HEIGHT && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT)));
-		}
-		if (HasRoughnessTextures) {
-			currentRoughness = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, RoughnessTextures, RoughnessTexturesNearest, false);
-		}
-		if (HasHeightTextures) {
-			currentHeight = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, HeightTextures, HeightTexturesNearest, false);
-		}
+        if (HasRoughnessTextures) {
+            vec4 roughnessTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal,
+                                              RoughnessTextures, RoughnessTexturesNearest, false);
+            roughness = roughnessTexture.r;
+        } else if (AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS) {
+            roughness = dominantTexture.a;
+        } else {
+            roughness = 1.0;
+        }
 
-		vec4 currentSplatmap = texture(Splatmaps, splatmapUV);
-		float channelValue = getChannelValue(currentChannel, currentSplatmap);
+        if (HasNormalTextures) {
+            vec4 normalTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal,
+                                           Normals, NormalsNearest, true);
+            normalMap = normalTexture.rgb;
 
-		float heightBlendedChannelValue = channelValue;
-		if (HasHeightTextures || AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT || NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT) {
-			heightBlendedChannelValue = min(contrast(BlendFactor, currentHeight.x) + channelValue, 1.0) * sqrt(channelValue);
-		}
-		channelSum += heightBlendedChannelValue;
+            if (NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS &&
+                AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_ROUGHNESS) {
+                roughness = normalTexture.a;
+            }
+        }
+    } else {
+        vec4 resultTexture = vec4(0.0);
+        vec4 resultNormal = vec4(0.0);
+        vec4 resultRoughness = vec4(0.0);
 
-		resultTexture += currentTexture * heightBlendedChannelValue;
-		resultNormal += currentNormal * heightBlendedChannelValue;
-		resultRoughness += currentRoughness * heightBlendedChannelValue;
+        vec3 zoneUV = calculateZoneUV(worldVertex);
 
-		if (currentChannel == 3) {
-			currentChannel = 0;
-		} else {
-			currentChannel++;
-		}
-	}
+        int currentChannel = 0;
+        float channelSum = 0.0;
+        for (int i = 0; i < NumberOfTextures; i++) {
+            int textureDetail = TexturesDetail[i];
+            vec2 worldVertexUV = worldVertex.xz * (float(textureDetail) * (1.0 / ZonesSize));
+            vec3 textureUV = vec3(worldVertexUV.x, worldVertexUV.y, float(i));
+            vec3 textureZoneUV = zoneUV;
+            if (Resolution > 1.0) {
+                textureZoneUV = calculateZoneUVResolution(worldVertex, false);
+            }
+            vec3 splatmapUV = vec3(textureZoneUV.x, textureZoneUV.y, floor(float(i/4)) + (textureZoneUV.z * ceil(float(NumberOfTextures) / 4.0)));
 
-	albedo = resultTexture.xyz / channelSum;
+            vec4 currentTexture = vec4(0);
+            vec4 currentNormal = vec4(0);
+            vec4 currentRoughness = vec4(0);
+            vec4 currentHeight = vec4(0);
 
-	if (ApplyLockTextures) {
-		vec4 lockTexture = texture(LockTextures, zoneUV);
-		float lockValue = (1.0 - lockTexture.r);
-		albedo *= vec3(max(lockValue, 0.5), lockValue, lockValue);
-	}
+            currentTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Textures, TexturesNearest, false);
+            currentRoughness = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS));
+            currentHeight = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT));
+            if (HasNormalTextures) {
+                currentNormal = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Normals, NormalsNearest, true);
+                currentRoughness = max(currentRoughness, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_ROUGHNESS && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS)));
+                currentHeight = max(currentHeight, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_HEIGHT && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT)));
+            }
+            if (HasRoughnessTextures) {
+                currentRoughness = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, RoughnessTextures, RoughnessTexturesNearest, false);
+            }
+            if (HasHeightTextures) {
+                currentHeight = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, HeightTextures, HeightTexturesNearest, false);
+            }
 
-	if (HasRoughnessTextures || AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS || NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS) {
-		roughness = resultRoughness.x / channelSum;
-	}
+            vec4 currentSplatmap = texture(Splatmaps, splatmapUV);
+            float channelValue = getChannelValue(currentChannel, currentSplatmap);
 
-	if (HasNormalTextures) {
-		normalMap = resultNormal.xyz / channelSum;
-	}
+            float heightBlendedChannelValue = channelValue;
+            if (HasHeightTextures || AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT || NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT) {
+                heightBlendedChannelValue = min(contrast(BlendFactor, currentHeight.x) + channelValue, 1.0) * sqrt(channelValue);
+            }
+            channelSum += heightBlendedChannelValue;
 
-	alpha = 1.0;
-	alphaScissorThreshold = 1.0;
+            resultTexture += currentTexture * heightBlendedChannelValue;
+            resultNormal += currentNormal * heightBlendedChannelValue;
+            resultRoughness += currentRoughness * heightBlendedChannelValue;
 
-	if (zoneUV.z < 0.0) {
-		alpha = 0.0;
-	} else {
-		float hole = texture(HeightmapTextures, zoneUV).g;
-		if (hole > 0.0) {
-			alpha = 0.0;
-		}
-	}
+            if (currentChannel == 3) {
+                currentChannel = 0;
+            } else {
+                currentChannel++;
+            }
+        }
+
+        albedo = resultTexture.xyz / channelSum;
+
+        if (HasRoughnessTextures || AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS || NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS) {
+            roughness = resultRoughness.x / channelSum;
+        }
+
+        if (HasNormalTextures) {
+            normalMap = resultNormal.xyz / channelSum;
+        }
+    }
+
+    vec3 zoneUV = calculateZoneUV(worldVertex);
+
+    if (ApplyLockTextures) {
+        vec4 lockTexture = texture(LockTextures, zoneUV);
+        float lockValue = (1.0 - lockTexture.r);
+        albedo *= vec3(max(lockValue, 0.5), lockValue, lockValue);
+    }
+
+    alpha = 1.0;
+    alphaScissorThreshold = 1.0;
+
+    if (zoneUV.z < 0.0) {
+        alpha = 0.0;
+    } else {
+        float hole = texture(HeightmapTextures, zoneUV).g;
+        if (hole > 0.0) {
+            alpha = 0.0;
+        }
+    }
 }

--- a/addons/terrabrush/Scripts/StringNames.cs
+++ b/addons/terrabrush/Scripts/StringNames.cs
@@ -79,4 +79,5 @@ internal static class StringNames {
     public static readonly StringName Resolution = "Resolution";
     public static readonly StringName Triplanar = "Triplanar";
     public static readonly StringName TexturesTriplanar = "TexturesTriplanar";
+    public static readonly StringName UseSharpTransitions = "UseSharpTransitions";
 }

--- a/addons/terrabrush/Scripts/Terrain.cs
+++ b/addons/terrabrush/Scripts/Terrain.cs
@@ -35,6 +35,7 @@ public partial class Terrain : Node3D {
     [Export] public float HeightBlendFactor { get;set; } = 10f;
     [Export] public AlphaChannelUsage AlbedoAlphaChannelUsage { get;set; } = AlphaChannelUsage.None;
     [Export] public AlphaChannelUsage NormalAlphaChannelUsage { get;set; } = AlphaChannelUsage.None;
+    [Export] public bool UseSharpTransitions { get;set; } = false;
     [Export] public float WaterFactor { get;set; }
     [Export] public Texture2D DefaultTexture { get;set; }
     [Export(PropertyHint.Layers3DRender)] public int VisualInstanceLayers { get;set; } = 1;
@@ -250,6 +251,7 @@ public partial class Terrain : Node3D {
             Clipmap.Shader.SetShaderParameter(StringNames.TexturesTriplanar, TextureSets.TextureSets.Select(x => x.Triplanar ? 1 : 0).ToArray());
             Clipmap.Shader.SetShaderParameter($"Textures{filterParamName}", textureArray);
             Clipmap.Shader.SetShaderParameter(StringNames.NumberOfTextures, textureArray.GetLayers());
+            Clipmap.Shader.SetShaderParameter(StringNames.UseSharpTransitions, UseSharpTransitions);
 
             if (this.TextureSets.TextureSets.Any(x => x.NormalTexture != null)) {
                 var normalArray = Utils.TexturesToTextureArray(this.TextureSets.TextureSets.Select(x => x.NormalTexture));

--- a/addons/terrabrush/TerraBrush.cs
+++ b/addons/terrabrush/TerraBrush.cs
@@ -168,6 +168,9 @@ public partial class TerraBrush : TerraBrushTool {
     [Export]
     public AlphaChannelUsage NormalAlphaChannelUsage { get;set; } = AlphaChannelUsage.None;
 
+    [Export]
+    public bool UseSharpTransitions { get;set; } = false;
+
     [ExportGroup("Foliage")]
     [Export]
     public override FoliageResource[] Foliages { get;set; }
@@ -361,6 +364,8 @@ public partial class TerraBrush : TerraBrushTool {
         _terrain.CreateCollisionInThread = CreateCollisionInThread;
 
         AddChild(_terrain);
+        
+        ApplySharpTransitionsSetting();
 
         await CreateObjects();
 
@@ -370,6 +375,14 @@ public partial class TerraBrush : TerraBrushTool {
         }
 
         EmitSignal(StringNames.TerrainLoaded);
+    }
+
+    private void ApplySharpTransitionsSetting()
+    {
+        if (_terrain != null && _terrain.Clipmap != null && _terrain.Clipmap.Shader != null)
+        {
+            _terrain.Clipmap.Shader.SetShaderParameter("UseSharpTransitions", UseSharpTransitions);
+        }
     }
 
     public override async void OnUpdateTerrainSettings() {
@@ -403,6 +416,11 @@ public partial class TerraBrush : TerraBrushTool {
         TerrainSettingsUpdated?.Invoke();
     }
 
+    public void UpdateSharpTransitions()
+    {
+        ApplySharpTransitionsSetting();
+    }
+
     public void ClearObjects() {
         if (_objectsContainerNode != null) {
             _objectsContainerNode.QueueFree();
@@ -416,7 +434,7 @@ public partial class TerraBrush : TerraBrushTool {
         if (zone.SplatmapsTexture == null || zone.SplatmapsTexture.Length < numberOfSplatmaps) {
             var newList = new List<ImageTexture>(zone.SplatmapsTexture ?? Array.Empty<ImageTexture>());
 
-			for (var i = zone.SplatmapsTexture?.Length ?? 0; i < numberOfSplatmaps; i++) {
+            for (var i = zone.SplatmapsTexture?.Length ?? 0; i < numberOfSplatmaps; i++) {
                 newList.Add(ZoneUtils.CreateSplatmapImage(ZonesSize, zone.ZonePosition, i, DataPath));
             }
 

--- a/addons/terrabrush/TerraBrush.cs
+++ b/addons/terrabrush/TerraBrush.cs
@@ -168,9 +168,6 @@ public partial class TerraBrush : TerraBrushTool {
     [Export]
     public AlphaChannelUsage NormalAlphaChannelUsage { get;set; } = AlphaChannelUsage.None;
 
-    [Export]
-    public bool UseSharpTransitions { get;set; } = false;
-
     [ExportGroup("Foliage")]
     [Export]
     public override FoliageResource[] Foliages { get;set; }
@@ -356,6 +353,7 @@ public partial class TerraBrush : TerraBrushTool {
         _terrain.HeightBlendFactor = HeightBlendFactor;
         _terrain.AlbedoAlphaChannelUsage = AlbedoAlphaChannelUsage;
         _terrain.NormalAlphaChannelUsage = NormalAlphaChannelUsage;
+        _terrain.UseSharpTransitions = UseSharpTransitions;
         _terrain.WaterFactor = WaterDefinition?.WaterFactor ?? 0;
         _terrain.LODLevels = LODLevels;
         _terrain.LODRowsPerLevel = LODRowsPerLevel;
@@ -364,8 +362,6 @@ public partial class TerraBrush : TerraBrushTool {
         _terrain.CreateCollisionInThread = CreateCollisionInThread;
 
         AddChild(_terrain);
-        
-        ApplySharpTransitionsSetting();
 
         await CreateObjects();
 
@@ -375,14 +371,6 @@ public partial class TerraBrush : TerraBrushTool {
         }
 
         EmitSignal(StringNames.TerrainLoaded);
-    }
-
-    private void ApplySharpTransitionsSetting()
-    {
-        if (_terrain != null && _terrain.Clipmap != null && _terrain.Clipmap.Shader != null)
-        {
-            _terrain.Clipmap.Shader.SetShaderParameter("UseSharpTransitions", UseSharpTransitions);
-        }
     }
 
     public override async void OnUpdateTerrainSettings() {
@@ -414,11 +402,6 @@ public partial class TerraBrush : TerraBrushTool {
 
         await LoadTerrain();
         TerrainSettingsUpdated?.Invoke();
-    }
-
-    public void UpdateSharpTransitions()
-    {
-        ApplySharpTransitionsSetting();
     }
 
     public void ClearObjects() {

--- a/addons/terrabrush/TerraBrush.cs
+++ b/addons/terrabrush/TerraBrush.cs
@@ -168,6 +168,9 @@ public partial class TerraBrush : TerraBrushTool {
     [Export]
     public AlphaChannelUsage NormalAlphaChannelUsage { get;set; } = AlphaChannelUsage.None;
 
+    [Export]
+    public bool UseSharpTransitions { get;set; } = false;
+
     [ExportGroup("Foliage")]
     [Export]
     public override FoliageResource[] Foliages { get;set; }

--- a/addons/terrabrush/plugin.cfg
+++ b/addons/terrabrush/plugin.cfg
@@ -3,5 +3,5 @@
 name="TerraBrush"
 description=""
 author="spimort"
-version="0.12.3-alpha"
+version="0.12.4-alpha"
 script="Plugin.cs"


### PR DESCRIPTION
This PR introduces a new texture blending option inspired by games like A Short Hike, which creates crisp terrain transitions instead of the standard smooth blending.

## What's Changed

- Added a new `UseSharpTransitions` toggle in the **TerraBrush Texture** settings
- Modified the terrain shader to support a "winner takes all" texture blending approach
- Preserved all existing functionality (height maps, normals, triplanar mapping, etc.)

## How It Works
The standard terrain texture blending gradually mixes multiple textures based on splatmap values, creating smooth transitions. With this new option, only the dominant texture is displayed at each point - the texture with the highest splatmap value "wins" and is shown exclusively.

This creates a more stylized, low-fidelity aesthetic with sharp, defined edges between different terrain types. Height maps can still influence which texture wins, preserving the terrain contour logic, but without the gradual blending.
The feature is entirely optional and can be toggled on/off through the inspector (terrain update required).

<img width="348" alt="Screenshot 2025-04-02 at 1 38 59 PM" src="https://github.com/user-attachments/assets/38630202-d140-4e9c-80b8-6912deac1a3c" />
.

## Visual Comparison

### Before
<img width="500" alt="Screenshot 2025-04-02 at 1 39 53 PM" src="https://github.com/user-attachments/assets/11b01352-9309-4c0a-8ead-385084b101c4" />
<img width="500" alt="Screenshot 2025-04-02 at 1 38 50 PM" src="https://github.com/user-attachments/assets/325a87aa-ba77-4d44-8f0c-4c11394e0202" />

### After
<img width="500" alt="Screenshot 2025-04-02 at 1 39 44 PM" src="https://github.com/user-attachments/assets/d2df826d-80ca-4257-ba8d-966ce5ff831f" />
<img width="500" alt="Screenshot 2025-04-02 at 1 39 10 PM" src="https://github.com/user-attachments/assets/e28eb22d-f03c-44b0-89e5-b9f980afd53d" />

The sharp transitions mode is perfect for stylized games, cartoon aesthetics, or any project aiming for a more distinct separation between terrain types.