### PR TITLE
Fix GodotObjects not being freed

### DIFF
--- a/Demo.cs
+++ b/Demo.cs
@@ -79,6 +79,11 @@ public partial class Demo : CharacterBody3D {
 							Main Texture : {(result.Textures?.Length > 0 ? result.Textures?[0].Factor : "")} - {(result.Textures?.Length > 0 ? result.Textures?[0].Name : "")}
 							Meta Info : {result.MetaInfoIndex} - {result.MetaInfoName}
 						""".Trim();
+
+					if (result.Textures is not null)
+						foreach (var t in result.Textures)
+							t.Free();
+					result.Free();
 				}
 				else {
 					debugText = $"{debugText} : No zone";


### PR DESCRIPTION
All GodotObjects need to be freed after use. 

## Before
<img width="827" height="265" alt="image" src="https://github.com/user-attachments/assets/64c2a22d-bbd0-40f3-9893-fac105bb316f" />

## After
<img width="821" height="294" alt="image" src="https://github.com/user-attachments/assets/36ff05ce-e1f0-4d24-ac95-7cc1439f5fec" />
