### PR TITLE
Add iOS platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ mono_crash.*.json
 
 # SCons
 .sconsign.dblite
+build/
 
 # TerraBrush
 demo/addons/terrabrush/bin

--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import subprocess
 
 env = SConscript("godot-cpp/SConstruct")
 
@@ -34,16 +35,47 @@ if env["platform"] == "macos":
         source=sources,
     )
 elif env["platform"] == "ios":
+    # For iOS, we need to combine TerraBrush static library with godot-cpp static library
+    # because static libraries don't auto-link dependencies like shared libraries do
+
+    # Determine the godot-cpp library path based on target and architecture
+    godot_cpp_target = env["target"]  # template_debug or template_release
+    godot_cpp_arch = env["arch"]
     if env["ios_simulator"]:
-        library = env.StaticLibrary(
-            "demo/addons/terrabrush/bin/terrabrush.{}.{}.simulator.a".format(env["platform"], targetEnv),
-            source=sources,
-        )
+        godot_cpp_lib = "godot-cpp/bin/libgodot-cpp.ios.{}.{}.simulator.a".format(godot_cpp_target, godot_cpp_arch)
     else:
-        library = env.StaticLibrary(
-            "demo/addons/terrabrush/bin/terrabrush.{}.{}.a".format(env["platform"], targetEnv),
-            source=sources,
-        )
+        godot_cpp_lib = "godot-cpp/bin/libgodot-cpp.ios.{}.{}.a".format(godot_cpp_target, godot_cpp_arch)
+
+    # Build TerraBrush static library first (intermediate - stored in build/ to keep bin/ clean)
+    if env["ios_simulator"]:
+        terrabrush_intermediate = "build/libterrabrush_only.{}.{}.simulator.a".format(env["platform"], targetEnv)
+        combined_output = "demo/addons/terrabrush/bin/libterrabrush.{}.{}.simulator.a".format(env["platform"], targetEnv)
+    else:
+        terrabrush_intermediate = "build/libterrabrush_only.{}.{}.a".format(env["platform"], targetEnv)
+        combined_output = "demo/addons/terrabrush/bin/libterrabrush.{}.{}.a".format(env["platform"], targetEnv)
+
+    terrabrush_lib = env.StaticLibrary(terrabrush_intermediate, source=sources)
+
+    # Create a command to combine both static libraries using libtool
+    def combine_static_libs(target, source, env):
+        """Combine multiple static libraries into one using libtool"""
+        target_path = str(target[0])
+        source_paths = [str(s) for s in source]
+        cmd = ["libtool", "-static", "-o", target_path] + source_paths
+        print("Combining static libraries: {}".format(" ".join(cmd)))
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print("libtool error: {}".format(result.stderr))
+            return 1
+        return 0
+
+    # Create the combined library
+    combined_lib = env.Command(
+        combined_output,
+        [terrabrush_lib, godot_cpp_lib],
+        combine_static_libs
+    )
+    library = combined_lib
 else:
     library = env.SharedLibrary(
         "demo/addons/terrabrush/bin/libterrabrush.{}.{}.{}{}".format(env["platform"], targetEnv, env["arch"], env["SHLIBSUFFIX"]),

--- a/build-tools/build_ios.sh
+++ b/build-tools/build_ios.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")/.."
+scons platform=ios arch=arm64 target=template_release

--- a/build-tools/build_ios_debug.sh
+++ b/build-tools/build_ios_debug.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")/.."
+scons platform=ios arch=arm64 target=template_debug debug_symbols=yes

--- a/demo/addons/terrabrush/terrabrush.gdextension
+++ b/demo/addons/terrabrush/terrabrush.gdextension
@@ -22,3 +22,6 @@ macos.release = "res://addons/terrabrush/bin/libterrabrush.macos.release.framewo
 
 web.debug = "res://addons/terrabrush/bin/libterrabrush.web.debug.wasm32.wasm"
 web.release = "res://addons/terrabrush/bin/libterrabrush.web.release.wasm32.wasm"
+
+ios.debug = "res://addons/terrabrush/bin/libterrabrush.ios.debug.a"
+ios.release = "res://addons/terrabrush/bin/libterrabrush.ios.release.a"


### PR DESCRIPTION
## Summary

This PR adds iOS build support to TerraBrush, enabling terrain functionality in Godot iOS exports.

- Modified `SConstruct` to combine TerraBrush + godot-cpp static libraries for iOS (required because static libraries don't auto-link dependencies)
- Added iOS entries to `terrabrush.gdextension`
- Added `build_ios.sh` and `build_ios_debug.sh` build scripts
- Added `build/` to `.gitignore` for intermediate build artifacts

## Why This Is Needed

iOS requires static libraries (`.a`) instead of shared libraries. Unlike `SharedLibrary` (macOS/Linux/Windows/Web) which links dependencies automatically, `StaticLibrary` only archives object files without resolving external symbols.

Without this fix, Xcode fails with hundreds of "undefined symbol" errors:
```
Undefined symbol: godot::Dictionary::Dictionary()
Undefined symbol: godot::BaseButton::set_pressed(bool)
Undefined symbol: godot::RefCounted::unreference()
... and many more
```

## The Fix

The build now combines both static libraries using `libtool -static`:
1. Build TerraBrush as intermediate static library (`build/libterrabrush_only.ios.*.a`)
2. godot-cpp builds its static library (`godot-cpp/bin/libgodot-cpp.ios.*.a`)
3. Combine both into final output (`demo/addons/terrabrush/bin/libterrabrush.ios.*.a`)

## Build Instructions

```bash
# Release
./build-tools/build_ios.sh

# Debug
./build-tools/build_ios_debug.sh
```

## Test Plan

- [x] Built iOS release library successfully
- [x] Built iOS debug library successfully
- [x] Verified combined library contains godot-cpp symbols (`nm -g` shows `T` entries)
- [x] Tested Godot iOS export
- [x] Tested Xcode build - compiles and links successfully
- [x] Tested on iOS device - TerraBrush terrain works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)