### PR TITLE
Fix WebGL2 sampler unit collision in heightmap clipmap (#304)

### DIFF
--- a/demo/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader_include.gdshaderinc
+++ b/demo/addons/terrabrush/Resources/Shaders/heightmap_clipmap_shader_include.gdshaderinc
@@ -6,18 +6,18 @@ uniform sampler2DArray LockTextures : hint_default_black;
 uniform sampler2DArray WaterTextures : hint_default_transparent, repeat_disable;
 uniform float WaterFactor = 1;
 uniform sampler2DArray Textures : source_color, filter_linear_mipmap;
-uniform sampler2DArray TexturesNearest : source_color, filter_nearest_mipmap;
+// REMOVED duplicate (WebGL2 sampler unit collision fix - issue #304): uniform sampler2DArray Textures : source_color, filter_nearest_mipmap;
 uniform sampler2DArray Splatmaps : repeat_disable;
 uniform int[100] TexturesDetail;
 uniform int NumberOfTextures;
 uniform sampler2DArray Normals : filter_linear_mipmap;
-uniform sampler2DArray NormalsNearest : filter_nearest_mipmap;
+// REMOVED duplicate (WebGL2 sampler unit collision fix - issue #304): uniform sampler2DArray Normals : filter_nearest_mipmap;
 uniform bool HasNormalTextures;
 uniform sampler2DArray RoughnessTextures : filter_linear_mipmap;
-uniform sampler2DArray RoughnessTexturesNearest : filter_nearest_mipmap;
+// REMOVED duplicate (WebGL2 sampler unit collision fix - issue #304): uniform sampler2DArray RoughnessTextures : filter_nearest_mipmap;
 uniform bool HasRoughnessTextures;
 uniform sampler2DArray HeightTextures : filter_linear_mipmap;
-uniform sampler2DArray HeightTexturesNearest : filter_nearest_mipmap;
+// REMOVED duplicate (WebGL2 sampler unit collision fix - issue #304): uniform sampler2DArray HeightTextures : filter_nearest_mipmap;
 uniform bool HasHeightTextures;
 uniform bool UseAntitile = true;
 uniform float BlendFactor;
@@ -225,10 +225,10 @@ int findDominantTextureIndex(vec3 worldVertex) {
             vec4 heightSample = vec4(0.0);
             if (HasHeightTextures) {
                 heightSample = getVec4Texture(textureUV, vec3(0.0), vec3(0.0),
-                                        HeightTextures, HeightTexturesNearest, false);
+                                        HeightTextures, HeightTextures, false);
             } else {
                 vec4 albedoSample = getVec4Texture(textureUV, vec3(0.0), vec3(0.0),
-                                          Textures, TexturesNearest, false);
+                                          Textures, Textures, false);
                 heightSample.r = albedoSample.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT);
             }
 
@@ -272,13 +272,13 @@ void calculateHeightmapFragment(
         vec3 textureUV = vec3(worldVertexUV.x, worldVertexUV.y, float(dominantTextureIndex));
 
         vec4 dominantTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal,
-                                           Textures, TexturesNearest, false);
+                                           Textures, Textures, false);
 
         albedo = dominantTexture.rgb;
 
         if (HasRoughnessTextures) {
             vec4 roughnessTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal,
-                                              RoughnessTextures, RoughnessTexturesNearest, false);
+                                              RoughnessTextures, RoughnessTextures, false);
             roughness = roughnessTexture.r;
         } else if (AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS) {
             roughness = dominantTexture.a;
@@ -288,7 +288,7 @@ void calculateHeightmapFragment(
 
         if (HasNormalTextures) {
             vec4 normalTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal,
-                                           Normals, NormalsNearest, true);
+                                           Normals, Normals, true);
             normalMap = normalTexture.rgb;
 
             if (NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS &&
@@ -355,19 +355,19 @@ void calculateHeightmapFragment(
 			float currentMetallic = 0.0;
 			float currentSpecular = 0.0;
 
-            currentTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Textures, TexturesNearest, false);
+            currentTexture = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Textures, Textures, false);
             currentRoughness = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS));
             currentHeight = vec4(currentTexture.a * float(AlbedoAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT));
             if (HasNormalTextures) {
-                currentNormal = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Normals, NormalsNearest, true);
+                currentNormal = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, Normals, Normals, true);
                 currentRoughness = max(currentRoughness, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_ROUGHNESS && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_ROUGHNESS)));
                 currentHeight = max(currentHeight, vec4(currentNormal.a * float(AlbedoAlphaChannelUsage != ALPHA_CHANNEL_USAGE_HEIGHT && NormalAlphaChannelUsage == ALPHA_CHANNEL_USAGE_HEIGHT)));
             }
             if (HasRoughnessTextures) {
-                currentRoughness = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, RoughnessTextures, RoughnessTexturesNearest, false);
+                currentRoughness = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, RoughnessTextures, RoughnessTextures, false);
             }
             if (HasHeightTextures) {
-                currentHeight = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, HeightTextures, HeightTexturesNearest, false);
+                currentHeight = getVec4Texture(textureUV, triplanarPos, triplanarPowerNormal, HeightTextures, HeightTextures, false);
             }
 
 			currentMetallic = TexturesMetallic[i];


### PR DESCRIPTION
## Summary

Resolves #304 — terrain renders fully transparent on the Compatibility renderer / WebGL2 / Apple Metal-backed GL, with the browser console spamming `GL_INVALID_OPERATION: glDrawArrays: Two textures of different types use the same sampler location` (256+ times per frame).

## Root cause

`heightmap_clipmap_shader_include.gdshaderinc` declares **14 sampler uniforms** in one shader stage:
- 13 × `sampler2DArray` (ColorTextures, LockTextures, WaterTextures, Textures + TexturesNearest, Splatmaps, Normals + NormalsNearest, RoughnessTextures + RoughnessTexturesNearest, HeightTextures + HeightTexturesNearest, MetaInfoTextures, plus HeightmapTextures via include)
- 1 × `sampler2D` ZonesMap (via `zones_shader_include.gdshaderinc`)

In WebGL2 / GLES 3.0 every uniform sampler the linker can't prove is dead defaults to texture image unit 0 if the host application doesn't explicitly bind it. On strict drivers (ANGLE on Windows/Mac browsers, Apple Metal-backed GL Compatibility) this exceeds the effective per-stage texture unit slot count and the `sampler2D ZonesMap` ends up sharing unit 0 with one of the `sampler2DArray` uniforms — producing the type-mismatch validation error and dropping the draw.

Symptom only appears under strict validators (ANGLE / Apple GL Compat), which is why the bug went unnoticed on Linux/Forward+ desktop testing but breaks web exports universally.

## Fix

Remove the four redundant "Nearest" `sampler2DArray` duplicates and rewire all call sites to use the Linear variants. Reduces per-stage sampler2DArray count from 13 → 9, freeing enough texture units that nothing collides on unit 0 and ZonesMap binds cleanly.

```diff
-uniform sampler2DArray TexturesNearest : source_color, filter_nearest_mipmap;
+// REMOVED duplicate (WebGL2 sampler unit collision fix - issue #304): uniform sampler2DArray TexturesNearest : source_color, filter_nearest_mipmap;
... (and 3 more similar)
```

Call sites that passed `(Textures, TexturesNearest)` etc. now pass `(Textures, Textures)`, etc.

## Tradeoff

The runtime `NearestFilter` uniform no longer toggles between filtered and pixelated terrain textures — both paths now use linear filtering. Most users won't notice. Pixel-art / chunky terrain projects that depend on the nearest mode will need a follow-up (e.g. consolidate filtering via sampler hint pairs, or split heightmap rendering into two specialized shaders).

If maintaining that mode is important, an alternative is to make the host application explicitly bind dummy `Texture2DArray` resources to every unused `sampler2DArray` uniform — that also resolves the collision without dropping any samplers. That's a bigger C++ change in `clipmap.cpp` though, and I haven't tested it.

## Test plan

- [x] macOS 15, Apple M4 Pro, Godot 4.6.2 stable, GL Compatibility (`--rendering-driver opengl3`): terrain renders, multi-zone visible, no `GL_INVALID_OPERATION` console spam.
- [x] Chrome 142 on macOS, Godot 4.6 web export (mobile renderer / WebGL2): terrain renders, multi-zone visible, no console spam.
- [x] No visible regression in the demo scene.

## Related

- Issue: #304
- Godot core sampler-binding bug context: godotengine/godot#108283