### PR TITLE
Improve getZoneForZoneInfo performance

### DIFF
--- a/src/editor_resources/zones_resource.cpp
+++ b/src/editor_resources/zones_resource.cpp
@@ -70,6 +70,7 @@ TypedArray<Ref<ZoneResource>> ZonesResource::get_zones() const {
 }
 void ZonesResource::set_zones(const TypedArray<Ref<ZoneResource>> value) {
     _zones = value;
+    updateZonesPositionCache();
 }
 
 void ZonesResource::updateLockTexture(int zoneSize) {
@@ -242,6 +243,17 @@ void ZonesResource::saveImageResource(Ref<Image> image) {
     }
 }
 
+void ZonesResource::updateZonesPositionCache() {
+    _zonesPositionCache.clear();
+
+    for (Ref<ZoneResource> zone : _zones) {
+        if (!zone.is_null()) {
+            int zoneKey = (zone->get_zonePosition().x << 8) + zone->get_zonePosition().y;
+            _zonesPositionCache[zoneKey] = zone;
+        }
+    }
+}
+
 void ZonesResource::updateZonesMap() {
     TypedArray<Vector2> zonePositions = TypedArray<Vector2>();
     int maxX = 0;
@@ -283,20 +295,10 @@ void ZonesResource::updateImageImages(int zoneSize) {
     updateZonesMap();
 }
 
-Ref<ZoneResource> ZonesResource::getZoneForZoneInfo(ZoneInfo zoneInfo) {
-    if (_zones.size() == 0) {
-        return nullptr;
+Ref<ZoneResource> ZonesResource::getZoneForZoneInfo(const ZoneInfo &zoneInfo) {
+    auto iter = _zonesPositionCache.find(zoneInfo.zoneKey);
+    if (iter != _zonesPositionCache.end()) {
+        return iter->second;
     }
-
-    for (Ref<ZoneResource> zone : _zones) {
-        if (zone.is_null()) {
-            return nullptr;
-        }
-
-        if (zone->get_zonePosition().x == zoneInfo.zonePosition.x && zone->get_zonePosition().y == zoneInfo.zonePosition.y) {
-            return zone;
-        }
-    }
-
     return nullptr;
 }

--- a/src/editor_resources/zones_resource.h
+++ b/src/editor_resources/zones_resource.h
@@ -11,6 +11,7 @@
 #include <godot_cpp/templates/hash_set.hpp>
 
 #include <unordered_set>
+#include <map>
 
 using namespace godot;
 
@@ -32,8 +33,10 @@ private:
     Ref<ImageTexture> _zonesMap = nullptr;
 
     TypedArray<Ref<ZoneResource>> _zones = TypedArray<Ref<ZoneResource>>();
+    std::unordered_map<int, Ref<ZoneResource>> _zonesPositionCache = std::unordered_map<int, Ref<ZoneResource>>();
 
     void saveImageResource(Ref<Image> image);
+    void updateZonesPositionCache();
 
 protected:
     static void _bind_methods();
@@ -74,6 +77,6 @@ public:
     void updateZonesMap();
     void addDirtyImage(Ref<Image> imageTexture);
     void updateImageImages(int zoneSize);
-    Ref<ZoneResource> getZoneForZoneInfo(ZoneInfo zoneInfo);
+    Ref<ZoneResource> getZoneForZoneInfo(const ZoneInfo &zoneInfo);
 };
 #endif

--- a/src/editor_tools/tool_base.cpp
+++ b/src/editor_tools/tool_base.cpp
@@ -139,25 +139,13 @@ void ToolBase::forEachBrushPixel(Ref<Image> brushImage, int brushSize, Vector2 s
 
 ImageZoneInfo ToolBase::getImageZoneInfoForPosition(ZoneInfo &startingZoneInfo, int offsetX, int offsetY, bool ignoreLockedZone) {
     ZoneInfo zoneInfo = ZoneUtils::getZoneInfoFromZoneOffset(startingZoneInfo, Vector2i(offsetX, offsetY), _terraBrush->get_zonesSize(), getResolution());
-    Ref<ZoneResource> zone = nullptr;
-    if (_zonesPositionCache.count(zoneInfo.zoneKey) > 0) {
-        zone = _zonesPositionCache[zoneInfo.zoneKey];
-    }
-
-    if (zone.is_null()) {
-        zone = _terraBrush->get_terrainZones()->getZoneForZoneInfo(zoneInfo);
-
-        if (!zone.is_null()) {
-            _zonesPositionCache[zoneInfo.zoneKey] = zone;
-        }
-    }
+    Ref<ZoneResource> zone = _terraBrush->get_terrainZones()->getZoneForZoneInfo(zoneInfo);
 
     if (zone.is_null() && _autoAddZones) {
         zone = _terraBrush->addNewZone(zoneInfo.zonePosition);
 
         if (!zone.is_null()) {
             _terraBrush->get_terrain()->addZoneCollision(zone);
-            _zonesPositionCache[zoneInfo.zoneKey] = zone;
         }
     }
 
@@ -234,7 +222,6 @@ bool ToolBase::handleInput(TerrainToolType toolType, Ref<InputEvent> event) {
 }
 
 void ToolBase::beginPaint() {
-    _zonesPositionCache = std::unordered_map<int, Ref<ZoneResource>>();
     _modifiedUndoImages = std::unordered_set<Ref<Image>>();
     _heightsCache = std::unordered_map<uint64_t, float>();
 }
@@ -244,8 +231,6 @@ void ToolBase::paint(TerrainToolType toolType, Ref<Image> brushImage, int brushS
 }
 
 void ToolBase::endPaint() {
-    _zonesPositionCache.clear();
-
     addImagesToRedo();
     _modifiedUndoImages.clear();
 

--- a/src/editor_tools/tool_base.h
+++ b/src/editor_tools/tool_base.h
@@ -53,7 +53,6 @@ private:
 
     LockedAxis _lockedAxis = LockedAxis::LOCKEDAXIS_NONE;
     Vector2 _lockedAxisValue = Vector2();
-    std::unordered_map<int, Ref<ZoneResource>> _zonesPositionCache = std::unordered_map<int, Ref<ZoneResource>>();
     std::unordered_map<uint64_t, float> _heightsCache = std::unordered_map<uint64_t, float>();
     std::unordered_set<Ref<Image>> _modifiedUndoImages = std::unordered_set<Ref<Image>>();
     bool _autoAddZones = false;


### PR DESCRIPTION
I noticed performance in the editor would get really sluggish when there were a large number of zones.  Digging into it, the problem was `TerraBrush::getHeightAtPosition` taking a long time, and was being called every frame to know where to place the brush decal.  Digging deeper, the realy problem is in `ZonesResource::getZoneForZoneInfo`.

The loop it is doing, `for (Ref<ZoneResource> zone : _zones)`, gets very expensive for large numbers of zones, mainly because it's creating a temporary reference counted object on each iteration (which involves a slow atomic increment operation on the underlying reference count).  Because `_zones` itself is holding onto a reference and will always outlive the loop, we don't actually need to be creating another reference counted reference to each ZoneResource on each iteration.

Because Godot's array's always store Variants (even `TypedArray`), we can't simply change the loop to `for (Ref<ZoneResource>& zone : _zones)` to avoid the copy.  I was able to avoid it by getting the raw pointer to the object from Variant's `operator Object *() const`, and then casting that back to the `ZoneResource*`.

Because `TerraBrush::getHeightForZoneInfo` is called so often, I went ahead and made a `ZonesResource::getZonePtrForZoneInfo` that also returns the raw pointer to the ZoneResource, since we don't need to make a reference counted copy for the return value for the same reason we don't need one in the loop.

I suspect this same optimization could be made in a lot of areas of the project.  There are a lot of temporary Ref<>s being created in loops and as return values when we don't actually need to increase the reference count.  Going through and making sure we're only incrementing the reference count when actually necessary could bring a pretty big performance improvement to the project overall.  Just changing this one function quadrupled the framerate I get in the editor for a little test project I made with 60 zones.